### PR TITLE
Ensure Vercel recognizes Vite build output

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "framework": "vite",
+  "installCommand": "npm install",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
## Summary
- declare the Vercel config version and framework so deployments run the Vite build and serve `dist`
- keep install/build/output commands aligned with the Vite production build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6907b4f1ed408323b7fa21babad4a5a0