### PR TITLE
Configure Netlify build output

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,9 @@
 [build]
-  publish = "."
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "18"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary
- configure Netlify to run the Vite build and publish the generated dist directory
- pin the Netlify Node.js version to 18 for consistent build results

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6907d005996c8323a0ffbc002597d123