### PR TITLE
Disable Netlify Next.js plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
 
 [build.environment]
   NODE_VERSION = "18"
+  NETLIFY_NEXT_PLUGIN_SKIP = "true"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary
- configure Netlify build environment to skip the Next.js runtime plugin that was causing deployment failures

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6907d0e27bd48323906b907cdf876356