### PR TITLE
Add CI workflow for main branch pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on pushes to the main branch
- install dependencies and run the production build to ensure successful integration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690c7bea5da4832383baa3c822a802f3