### PR TITLE
Update CV site with 2025 resume details

### DIFF
--- a/src/components/CVWebsite.tsx
+++ b/src/components/CVWebsite.tsx
@@ -3,6 +3,7 @@ import Header from './layout/Header';
 import Navigation from './layout/Navigation';
 import Footer from './layout/Footer';
 import TimelineModal from './layout/TimelineModal';
+import CurrentPositionSection from './sections/CurrentPositionSection';
 import EducationSection from './sections/EducationSection';
 import AboutSection from './sections/AboutSection';
 import PublicationsSection from './sections/PublicationsSection';
@@ -96,6 +97,7 @@ const CVWebsite = () => {
       <Navigation sections={navSections} activeSection={activeSection} onNavigate={handleNavClick} />
 
       <main className="max-w-4xl mx-auto px-6 py-12">
+        <CurrentPositionSection isVisible={isSectionVisible('current')} />
         <EducationSection isVisible={isSectionVisible('education')} />
         <AboutSection isVisible={isSectionVisible('about')} />
         <PublicationsSection isVisible={isSectionVisible('publications')} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,7 +7,7 @@ const Header = () => (
             Gabriel del Carmen, MD
           </h1>
           <p className="text-sm text-gray-500 font-light">
-            General Surgery Resident (PGY-1) — Albany Medical Center | Expected Class of 2029
+            General Surgery Resident (PGY-2) — Albany Medical Center | Residency Class of 2029
           </p>
         </div>
       </div>

--- a/src/components/layout/TimelineModal.tsx
+++ b/src/components/layout/TimelineModal.tsx
@@ -2,6 +2,8 @@ interface TimelineModalProps {
   onClose: () => void;
 }
 
+const timelineYears = [2015, 2017, 2019, 2020, 2021, 2023, 2024, 2025, 2026];
+
 const TimelineModal = ({ onClose }: TimelineModalProps) => (
   <div className="fixed inset-0 z-40 flex items-center justify-center p-4 bg-gray-800 bg-opacity-70">
     <div className="relative max-w-4xl w-full rounded-lg p-6 shadow-xl bg-white">
@@ -20,8 +22,12 @@ const TimelineModal = ({ onClose }: TimelineModalProps) => (
       <div className="overflow-x-auto">
         <div className="min-w-max">
           <div className="h-1 bg-gray-200 relative mb-8">
-            {[2015, 2017, 2019, 2020, 2021, 2023, 2024, 2025].map((year, index) => (
-              <div key={year} className="absolute transform -translate-x-1/2" style={{ left: `${index * 14.28}%` }}>
+            {timelineYears.map((year, index) => (
+              <div
+                key={year}
+                className="absolute transform -translate-x-1/2"
+                style={{ left: `${(index / (timelineYears.length - 1)) * 100}%` }}
+              >
                 <div className="h-3 w-3 rounded-full bg-blue-500 mb-2"></div>
                 <span className="text-xs text-gray-600">{year}</span>
               </div>
@@ -54,6 +60,28 @@ const TimelineModal = ({ onClose }: TimelineModalProps) => (
             <div className="col-span-2 p-3 rounded bg-red-50">
               <h3 className="text-sm font-medium text-gray-800">Vilar Lab, MD Anderson</h3>
               <p className="text-xs text-gray-600">2021-2024</p>
+            </div>
+
+            <div className="col-span-2 p-3 rounded bg-indigo-50">
+              <h3 className="text-sm font-medium text-gray-800">Transplant Outcomes Research</h3>
+              <p className="text-xs text-gray-600">2021-2024</p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-7 gap-4 mt-4">
+            <div className="col-span-2 p-3 rounded bg-orange-50">
+              <h3 className="text-sm font-medium text-gray-800">AI & Ethics Scholarship</h3>
+              <p className="text-xs text-gray-600">2023-2025</p>
+            </div>
+
+            <div className="col-span-2 p-3 rounded bg-teal-50">
+              <h3 className="text-sm font-medium text-gray-800">Trauma Guidelines App</h3>
+              <p className="text-xs text-gray-600">Oct 2025</p>
+            </div>
+
+            <div className="col-span-2 p-3 rounded bg-pink-50">
+              <h3 className="text-sm font-medium text-gray-800">DrainBow Prototype</h3>
+              <p className="text-xs text-gray-600">Nov 2025</p>
             </div>
           </div>
         </div>

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -9,7 +9,15 @@ const AboutSection = ({ isVisible }: SectionProps) => (
   >
     <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">About</h2>
     <p className="text-gray-600 leading-relaxed font-light">
-      I am a surgical resident deeply committed to advancing patient-centered care through surgical excellence and medical ethics, with a strong dedication to reducing disparities in healthcare quality and access. My interests include developing, refining, and promoting the responsible adoption of artificial intelligence tools to augment patient-centered care and improve clinical outcomes. Passionate about the ethical integration of AI in medicine, I aim to ensure these technologies enhance patient experiences without compromising humanistic care. My professional aspiration is to actively contribute to a collaborative, academically rigorous environment that prioritizes innovation, equitable healthcare, and continuous progress in surgery and medical education.
+      I am an academic-minded general surgery resident focused on blending translational research, outcomes science, and
+      compassionate surgical care. My work centers on creating equitable systems that elevate patient voices, whether by
+      redesigning clinical trials for inclusivity, using natural language processing to surface disparities, or
+      strengthening mentorship pathways for future surgeons.
+    </p>
+    <p className="text-gray-600 leading-relaxed font-light mt-3">
+      Across every project I prioritize ethical reflection and responsible innovation—particularly in the integration of
+      artificial intelligence. I am motivated by collaborative environments where rigorous science, patient advocacy, and
+      thoughtful leadership move surgical oncology forward.
     </p>
   </section>
 );

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -13,7 +13,11 @@ const ContactSection = ({ isVisible }: SectionProps) => (
               <span className="text-gray-900">Email:</span> <a href="mailto:delcarg@amc.edu" className="text-gray-600 hover:text-gray-900 transition-colors">delcarg@amc.edu</a>
             </p>
             <p className="text-sm text-gray-600 font-light">
-              <span className="text-gray-900">Location:</span> Albany, NY
+              <span className="text-gray-900">Phone:</span>{' '}
+              <a href="tel:18173076735" className="text-gray-600 hover:text-gray-900 transition-colors">817-307-6735</a>
+            </p>
+            <p className="text-sm text-gray-600 font-light">
+              <span className="text-gray-900">Location:</span> 745 Broadway Unit 218, Albany, NY 12208
             </p>
             <p className="text-sm text-gray-600 font-light">
               <span className="text-gray-900">ORCID:</span> <a href="https://orcid.org/0000-0002-1857-8404" target="_blank" className="text-gray-600 hover:text-gray-900 transition-colors flex items-center">

--- a/src/components/sections/CurrentPositionSection.tsx
+++ b/src/components/sections/CurrentPositionSection.tsx
@@ -1,0 +1,55 @@
+interface SectionProps {
+  isVisible: boolean;
+}
+
+const CurrentPositionSection = ({ isVisible }: SectionProps) => (
+  <section
+    id="current"
+    className={`mb-16 transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
+  >
+    <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Current Position & Objective</h2>
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-base font-medium text-gray-900">General Surgery Resident, Post-Graduate Year 2</h3>
+        <p className="text-sm text-gray-500 mt-1">Department of Surgery, Albany Medical Center — Albany, NY</p>
+        <p className="text-sm text-gray-500">July 2024 – Present</p>
+        <p className="text-sm text-gray-600 font-light mt-3">
+          745 Broadway Unit 218, Albany, NY 12208 · 817-307-6735 ·{' '}
+          <a
+            href="mailto:delcarg@amc.edu"
+            className="text-gray-600 hover:text-gray-900 transition-colors"
+          >
+            delcarg@amc.edu
+          </a>
+        </p>
+      </div>
+
+      <div>
+        <h4 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Objective</h4>
+        <p className="text-gray-600 leading-relaxed font-light">
+          General surgery resident at Albany Medical Center pursuing opportunities to prepare for a career in academic
+          surgical oncology by building expertise in translational research, clinical trials, and clinical outcomes. I am
+          committed to comprehensive surgical skill development, cultivating leadership among future surgical leaders, and
+          supporting initiatives in healthcare equity.
+        </p>
+        <p className="text-gray-600 leading-relaxed font-light mt-3">
+          I bring a passion for patient-centered care, a deep interest in surgical and medical ethics, and a dedication to
+          reducing disparities in health quality and access. I thrive in collaborative, challenging, and academically
+          rigorous environments where innovation and compassionate care go hand in hand.
+        </p>
+      </div>
+
+      <div>
+        <h4 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Focus Areas</h4>
+        <ul className="list-disc pl-5 space-y-1 text-sm text-gray-600 font-light">
+          <li>Translational research that accelerates innovations in colorectal and hepatopancreatobiliary oncology.</li>
+          <li>Design and execution of clinical trials and outcomes research that foreground equity and patient experience.</li>
+          <li>Ethical integration of artificial intelligence to augment surgical decision-making without compromising humanity.</li>
+          <li>Mentorship and leadership development to empower interdisciplinary surgical teams.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+);
+
+export default CurrentPositionSection;

--- a/src/components/sections/EducationSection.tsx
+++ b/src/components/sections/EducationSection.tsx
@@ -10,11 +10,7 @@ const EducationSection = ({ isVisible }: SectionProps) => (
     <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Education</h2>
     <div className="space-y-8">
       <div>
-        <h3 className="text-base font-medium text-gray-900">Albany Medical Center, Albany, NY</h3>
-        <p className="text-sm text-gray-500 mt-1">General Surgery Resident, PGY-1 | Expected Graduation: 2029</p>
-      </div>
-      <div>
-        <h3 className="text-base font-medium text-gray-900">McGovern Medical School at UTHealth Houston, Houston, TX</h3>
+        <h3 className="text-base font-medium text-gray-900">McGovern Medical School at UTHealth Houston — Houston, TX</h3>
         <p className="text-sm text-gray-500 mt-1">Doctor of Medicine | August 2020 – May 2024</p>
         <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
           <li>• Scholarly Concentration in Medical Humanities</li>
@@ -22,13 +18,12 @@ const EducationSection = ({ isVisible }: SectionProps) => (
         </ul>
       </div>
       <div>
-        <h3 className="text-base font-medium text-gray-900">Brandeis University, Waltham, MA</h3>
-        <p className="text-sm text-gray-500 mt-1">B.S. Health: Science, Society, and Policy, B.A. Biology, B.A. Philosophy | 2015 – 2019</p>
+        <h3 className="text-base font-medium text-gray-900">Brandeis University — Waltham, MA</h3>
+        <p className="text-sm text-gray-500 mt-1">
+          Bachelor of Science in Health: Science, Society, and Policy · Bachelor of Arts in Biology · Bachelor of Arts in
+          Philosophy | August 2015 – May 2019
+        </p>
         <p className="text-sm text-gray-600 mt-2 font-light">Graduated cum laude</p>
-      </div>
-      <div>
-        <h3 className="text-base font-medium text-gray-900">Harvard University Secondary School Program, Cambridge, MA</h3>
-        <p className="text-sm text-gray-500 mt-1">Summer Programs | 2013, 2014</p>
       </div>
     </div>
   </section>

--- a/src/components/sections/ExperienceSection.tsx
+++ b/src/components/sections/ExperienceSection.tsx
@@ -7,42 +7,129 @@ const ExperienceSection = ({ isVisible }: SectionProps) => (
           id="experience" 
           className={`mb-16 transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
         >
-          <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Leadership Experience</h2>
-          <div className="space-y-8">
+          <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Leadership & Service</h2>
+          <div className="space-y-10">
             <div>
-              <h3 className="text-base font-medium text-gray-900">Gold Humanism Honor Society, McGovern Medical School</h3>
-              <p className="text-sm text-gray-500 mt-1">Internal Vice President | 2023 – 2024</p>
-              <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
-                <li>• Served as student liaison between student body and honor society</li>
-                <li>• Directed constitutional updates and revisions</li>
-              </ul>
+              <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-4">Medical School Leadership</h3>
+              <div className="space-y-6">
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">Gold Humanism Honor Society — McGovern Medical School</h4>
+                  <p className="text-sm text-gray-500 mt-1">Internal Vice President | April 2023 – May 2024</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Served as liaison between students and the chapter, representing the organization at formal functions.</li>
+                    <li>• Led constitutional revisions and operational planning for humanism-focused programming.</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">Clerkship Stream Captain — McGovern Medical School</h4>
+                  <p className="text-sm text-gray-500 mt-1">Stream Leader | May 2022 – May 2023</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Centralized clerkship logistics, contacts, and site-specific insights for the Class of 2024.</li>
+                    <li>• Maintained clear communication channels between students and academic leadership.</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">Wellness and Resilience Committee — McGovern Medical School</h4>
+                  <p className="text-sm text-gray-500 mt-1">Advocacy Subcommittee Lead & Co-President | August 2021 – May 2024</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Advocated for expanded counseling access and reduced financial barriers to student healthcare.</li>
+                    <li>• Authored an institutional FAQ to improve visibility of wellness resources.</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">Student Diversity Committee — McGovern Medical School</h4>
+                  <p className="text-sm text-gray-500 mt-1">Student Representative | August 2020 – May 2024</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Represented classmates on diversity, equity, and inclusion initiatives.</li>
+                    <li>• Mentored Cesar Chavez High School students on college readiness and healthcare careers.</li>
+                  </ul>
+                </div>
+              </div>
             </div>
-            
+
             <div>
-              <h3 className="text-base font-medium text-gray-900">Narrative Medicine and Reflection, McGovern Medical School</h3>
-              <p className="text-sm text-gray-500 mt-1">Class Coordinator | 2023 – 2024</p>
-              <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
-                <li>• Facilitated workshops on contemporary medical practice issues</li>
-                <li>• Organized sessions and facilitated discussions</li>
-              </ul>
+              <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-4">Mentorship & Education</h3>
+              <div className="space-y-6">
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">Gold Humanism Mentorship Program — McGovern Medical School</h4>
+                  <p className="text-sm text-gray-500 mt-1">Peer Mentor | April 2023 – May 2024</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Guided third-year students through compassionate care practices and leadership development.</li>
+                    <li>• Facilitated reflective conversations on empathy, professionalism, and humanism in medicine.</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">Summer Health Professions Education Program — McGovern Medical School</h4>
+                  <p className="text-sm text-gray-500 mt-1">Student Mentor | April 2023 – Present</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Led panels and workshops offering academic and career guidance to aspiring health professionals.</li>
+                    <li>• Provided individualized mentorship supporting professional identity formation.</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">Narrative Medicine & Reflection Elective — McGovern Medical School</h4>
+                  <p className="text-sm text-gray-500 mt-1">Class Coordinator | March 2023 – May 2024</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Designed workshops centered on narrative inquiry and ethics in contemporary medical practice.</li>
+                    <li>• Facilitated reflective writing sessions fostering clinician wellness and empathy.</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">Hot Topics in Ethics Elective — McGovern Medical School</h4>
+                  <p className="text-sm text-gray-500 mt-1">Course Coordinator | July 2021 – May 2022</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Curated weekly lecture series on bioethics with invited subject matter experts.</li>
+                    <li>• Organized case-based discussions examining ethical dilemmas across specialties.</li>
+                  </ul>
+                </div>
+              </div>
             </div>
-            
+
             <div>
-              <h3 className="text-base font-medium text-gray-900">Wellness and Resilience Committee, McGovern Medical School</h3>
-              <p className="text-sm text-gray-500 mt-1">Student Lead for Advocacy | 2021 – Present</p>
-              <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
-                <li>• Addressed health and wellness-related concerns</li>
-                <li>• Enhanced communication between students and counseling services</li>
-              </ul>
-            </div>
-            
-            <div>
-              <h3 className="text-base font-medium text-gray-900">Student Diversity Committee, McGovern Medical School</h3>
-              <p className="text-sm text-gray-500 mt-1">Student Representative | 2020 – 2024</p>
-              <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
-                <li>• Represented Class of 2024 on issues of inclusion and diversity</li>
-                <li>• Mentored high school students on career paths in healthcare</li>
-              </ul>
+              <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-4">Community & Wellness Advocacy</h3>
+              <div className="space-y-6">
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">Student Sexuality Information Services — Brandeis University</h4>
+                  <p className="text-sm text-gray-500 mt-1">Confidential Peer Counselor | August 2016 – May 2019</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Completed 60+ hours of annual training across reproductive health, sexual wellness, and crisis response.</li>
+                    <li>• Provided confidential counseling and resource navigation for peers.</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">Active Minds at Brandeis University</h4>
+                  <p className="text-sm text-gray-500 mt-1">President | January 2016 – December 2018</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Led campus-wide initiatives destigmatizing mental health and promoting help-seeking behaviors.</li>
+                    <li>• Organized educational programming and advocacy campaigns alongside peer institutions.</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">All For 1 Coalition — Brandeis University</h4>
+                  <p className="text-sm text-gray-500 mt-1">Co-Chair | June 2016 – May 2019</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Coordinated annual agendas and shared initiatives across partner universities.</li>
+                    <li>• Managed budgets and resource allocation for coalition-wide projects.</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h4 className="text-base font-medium text-gray-900">H.O.P.E. Institute Tutoring Center — Arlington, TX</h4>
+                  <p className="text-sm text-gray-500 mt-1">Student Tutor | May – July 2016</p>
+                  <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                    <li>• Supported elementary and middle school students through individualized academic coaching.</li>
+                    <li>• Partnered with families to develop strategies that improved student confidence and performance.</li>
+                  </ul>
+                </div>
+              </div>
             </div>
           </div>
         </section>

--- a/src/components/sections/ProgrammingSection.tsx
+++ b/src/components/sections/ProgrammingSection.tsx
@@ -29,108 +29,75 @@ const ProgrammingSection = ({ isVisible }: SectionProps) => (
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {/* Project 1: Surgic.AI */}
             <Tooltip
               content={
                 <div>
-                  <h4 className="font-medium mb-2">Surgic.AI - Enterprise Initiative</h4>
-                  <p className="mb-2">An enterprise focused on developing and deploying cutting-edge machine learning solutions tailored for medicine and surgery.</p>
-                  <p className="mb-2">Core Goals:</p>
+                  <h4 className="font-medium mb-2">Trauma Practice Management Guidelines</h4>
+                  <p className="mb-2">
+                    SwiftUI application centralizing Albany Medical Center&apos;s trauma practice management guidelines for rapid
+                    bedside reference.
+                  </p>
+                  <p className="mb-2">Key capabilities include:</p>
                   <ul className="list-disc pl-4 mb-2">
-                    <li>Enhance medical/surgical learning through AI tools.</li>
-                    <li>Improve the delivery of high-quality patient care.</li>
-                    <li>Mitigate physician burden through intelligent automation and support.</li>
-                    <li>Uphold rigorous ethical standards and patient safety in all applications.</li>
+                    <li>Offline-first architecture with locally cached guideline content organized by specialty.</li>
+                    <li>Global search with highlighted results to expedite decision-making.</li>
+                    <li>Responsive typography and color cues to differentiate urgency and procedural steps.</li>
+                    <li>Collaboration with institutional trauma leadership to ensure version control and governance.</li>
                   </ul>
-                  <p>Projects like Rounder and Synthetic CXR Generation fall under the Surgic.AI framework.</p>
+                  <p>Released October 2025 to support consistent trauma coverage across services.</p>
                 </div>
               }
               position="bottom"
               width="max-w-md"
             >
               <div className="bg-gray-50 p-5 rounded-lg transition-all hover:shadow-md cursor-help">
-                <h3 className="text-base font-medium text-gray-900 mb-2">Surgic.AI</h3>
-                <p className="text-sm text-gray-600 font-light mb-3">Enterprise initiative providing ML solutions to enhance learning and patient care in medicine/surgery.</p>
+                <h3 className="text-base font-medium text-gray-900 mb-2">Trauma Practice Management Guidelines</h3>
+                <p className="text-sm text-gray-600 font-light mb-3">
+                  SwiftUI app delivering searchable, offline trauma protocols for Albany Medical Center clinicians.
+                </p>
                 <div className="flex flex-wrap gap-2 mb-3">
-                  <span className="bg-purple-50 text-purple-700 text-xs px-2 py-1 rounded-full">AI/ML</span>
-                  <span className="bg-blue-50 text-blue-700 text-xs px-2 py-1 rounded-full">Healthcare Tech</span>
-                  <span className="bg-red-50 text-red-700 text-xs px-2 py-1 rounded-full">Enterprise</span>
-                  <span className="bg-green-50 text-green-700 text-xs px-2 py-1 rounded-full">Surgery</span>
+                  <span className="bg-blue-50 text-blue-700 text-xs px-2 py-1 rounded-full">SwiftUI</span>
+                  <span className="bg-green-50 text-green-700 text-xs px-2 py-1 rounded-full">Clinical Operations</span>
+                  <span className="bg-purple-50 text-purple-700 text-xs px-2 py-1 rounded-full">Offline-First</span>
                 </div>
-                {/* <a href="https://github.com/[Your-GitHub-Username]/surgic-ai" target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 hover:underline">View Project →</a> */}
-                <span className="text-sm text-gray-400">Website coming soon</span>
+                <span className="text-sm text-gray-400">Internal distribution</span>
               </div>
             </Tooltip>
 
-            {/* Project 2: Rounder App */}
             <Tooltip
               content={
                 <div>
-                  <h4 className="font-medium mb-2">Rounder - Clinical Workflow App</h4>
-                  <p className="mb-2">Mobile application designed to streamline clinical rounds documentation while maintaining HIPAA compliance.</p>
-                  <p className="mb-2">Key Features:</p>
+                  <h4 className="font-medium mb-2">DrainBow</h4>
+                  <p className="mb-2">
+                    Minimal viable product capturing drain photos, performing on-device color detection, and logging trends to
+                    support postoperative monitoring.
+                  </p>
+                  <p className="mb-2">Feature highlights:</p>
                   <ul className="list-disc pl-4 mb-2">
-                    <li>Voice-to-text note capture during rounds.</li>
-                    <li>Automatic formatting of notes into SOAP structure.</li>
-                    <li>Secure patient list creation via encrypted photo capture (OCR-based).</li>
-                    <li>Automatic assignment of notes to corresponding patients.</li>
-                    <li>Focus on hands-off operation to prioritize patient interaction.</li>
-                    <li>Ensures data privacy and security according to HIPAA standards.</li>
+                    <li>Secure photo capture workflow mapped to individual drains with timestamped entries.</li>
+                    <li>Color analysis rendered as &ldquo;rainbow&rdquo; visualization alongside volume data to surface concerning shifts.</li>
+                    <li>Local-first storage with exportable logs for integration into care team handoffs.</li>
+                    <li>Designed with surgical faculty to reduce cognitive load during high-volume rounds.</li>
                   </ul>
-                  <p>Currently under active development.</p>
+                  <p>Prototype completed November 2025; exploring institutional pilot opportunities.</p>
                 </div>
               }
               position="bottom"
               width="max-w-md"
             >
               <div className="bg-gray-50 p-5 rounded-lg transition-all hover:shadow-md cursor-help">
-                <h3 className="text-base font-medium text-gray-900 mb-2">Rounder App</h3>
-                <p className="text-sm text-gray-600 font-light mb-3">HIPAA-compliant app for efficient rounds notes (voice-to-SOAP, patient list photos).</p>
+                <h3 className="text-base font-medium text-gray-900 mb-2">DrainBow</h3>
+                <p className="text-sm text-gray-600 font-light mb-3">
+                  Local-first drain tracking app pairing color analytics with volume logs to spotlight postoperative changes.
+                </p>
                 <div className="flex flex-wrap gap-2 mb-3">
-                  <span className="bg-blue-50 text-blue-700 text-xs px-2 py-1 rounded-full">Mobile App</span>
-                  <span className="bg-green-50 text-green-700 text-xs px-2 py-1 rounded-full">Clinical Workflow</span>
-                  <span className="bg-yellow-50 text-yellow-700 text-xs px-2 py-1 rounded-full">AI/ML</span>
-                  <span className="bg-red-50 text-red-700 text-xs px-2 py-1 rounded-full">HIPAA</span>
+                  <span className="bg-blue-50 text-blue-700 text-xs px-2 py-1 rounded-full">SwiftUI</span>
+                  <span className="bg-pink-50 text-pink-700 text-xs px-2 py-1 rounded-full">Computer Vision</span>
+                  <span className="bg-yellow-50 text-yellow-700 text-xs px-2 py-1 rounded-full">On-Device ML</span>
                 </div>
-                <span className="text-sm text-gray-400">Preview coming soon</span>
+                <span className="text-sm text-gray-400">Prototype stage</span>
               </div>
             </Tooltip>
-
-            {/* Project 3: Synthetic CXR Generation */}
-            <Tooltip
-              content={
-                <div>
-                  <h4 className="font-medium mb-2">Synthetic Chest X-Ray (CXR) Generation</h4>
-                  <p className="mb-2">AI-powered tool to generate high-fidelity, anatomically accurate synthetic chest X-ray images for medical education.</p>
-                  <p className="mb-2">Project Goals:</p>
-                  <ul className="list-disc pl-4 mb-2">
-                    <li>Provide a diverse and extensive dataset for training residents and medical students.</li>
-                    <li>Generate images depicting various common and rare pathologies.</li>
-                    <li>Allow for controllable parameters to simulate different patient scenarios.</li>
-                    <li>Benchmark generative models (like GANs or Diffusion models) against real CXR datasets (e.g., VinDr-CXR) for fidelity.</li>
-                    <li>Integrate with educational platforms for interactive learning modules.</li>
-                  </ul>
-                  <p>Focuses on improving radiological interpretation skills without relying solely on limited real patient data.</p>
-                </div>
-              }
-              position="bottom"
-              width="max-w-md"
-            >
-              <div className="bg-gray-50 p-5 rounded-lg transition-all hover:shadow-md cursor-help">
-                <h3 className="text-base font-medium text-gray-900 mb-2">Synthetic CXR Generation</h3>
-                <p className="text-sm text-gray-600 font-light mb-3">AI tool generating realistic synthetic CXRs for medical education and training.</p>
-                <div className="flex flex-wrap gap-2 mb-3">
-                  <span className="bg-purple-50 text-purple-700 text-xs px-2 py-1 rounded-full">AI/ML</span>
-                  <span className="bg-orange-50 text-orange-700 text-xs px-2 py-1 rounded-full">Generative Models</span>
-                  <span className="bg-blue-50 text-blue-700 text-xs px-2 py-1 rounded-full">Medical Education</span>
-                  <span className="bg-green-50 text-green-700 text-xs px-2 py-1 rounded-full">Radiology</span>
-                </div>
-                <span className="text-sm text-gray-400">Preview coming soon</span>
-              </div>
-            </Tooltip>
-
-            {/* Add more projects as needed */}
-
           </div>
         </section>
 );

--- a/src/components/sections/PublicationsSection.tsx
+++ b/src/components/sections/PublicationsSection.tsx
@@ -4,526 +4,601 @@ interface SectionProps {
   isVisible: boolean;
 }
 
-const PublicationsSection = ({ isVisible }: SectionProps) => (
-  <section 
-          id="publications" 
-          className={`mb-16 transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
+type PublicationItem = {
+  id: string;
+  citation: JSX.Element;
+  details?: JSX.Element;
+};
+
+const originalPublications: PublicationItem[] = [
+  {
+    id: 'oara-2024',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Guthrie E, Levy D.{' '}
+        <a
+          href="https://pubmed.ncbi.nlm.nih.gov/38365551/"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline"
         >
-          <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Publications & Presentations
-            <span className="ml-2 text-xs text-gray-400 font-light inline-flex items-center">
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              Hover for details
-            </span>
-          </h2>
-          
-          <div className="mb-8">
-            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Book Chapters</h3>
-            <ul className="space-y-4 text-sm text-gray-600 font-light">
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Disseminated Intravascular Coagulopathy (Case Files)</h4>
-                    <p className="mb-2">Authored a comprehensive chapter for McGraw Hill's renowned Case Files series, delving into the complex mechanisms and management of DIC using a real-world patient scenario.</p>
-                    <p className="mb-2">Key contributions:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Explained the critical pathophysiology driving systemic coagulation breakdown.</li>
-                      <li>Highlighted essential diagnostic clues, including lab markers like D-dimer.</li>
-                      <li>Outlined tailored treatment strategies for diverse clinical contexts (sepsis, malignancy, obstetrics).</li>
-                      <li>Provided insights into predicting outcomes and managing life-threatening complications like organ failure.</li>
-                    </ul>
-                    <p>Impact: Equipping medical trainees with practical, case-based knowledge on a critical condition.</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>. Disseminated Intravascular Coagulopathy. In: Toy EC, Toy AL, eds. <em>Case Files Hematology Body System. Case Files Collection</em>, New York: McGraw Hill Publishers, In Press.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">The Mental Health Issue: And Why It Matters</h4>
-                    <p className="mb-2">A critical examination of the different criteria for mental pathologies, the common misrepresentations of mental illness as non-biological, and the path forward.</p>
-                    <p className="mb-2">This book addresses:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>A biological basis for mental health and illness</li>
-                      <li>Stigma reduction strategies both in medical and community settings</li>
-                      <li>Evidence-based approaches to mental healthcare integration</li>
-                      <li>Personal narratives illustrating lived experiences with mental illness</li>
-                    </ul>
-                    <p>Independently published in print and digitally.</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span> (2017). <em><a href="https://www.amazon.com/Mental-Health-Issue-Why-Matters/dp/1521327793" target="_blank" className="text-blue-600 hover:underline">The Mental Health Issue: And Why It Matters</a></em>. Independently Published. ISBN:1521327793</li>
-              </Tooltip>
-            </ul>
-          </div>
-          
-          <div className="mb-8">
-            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Peer-Reviewed Research Articles</h3>
-            <ul className="space-y-4 text-sm text-gray-600 font-light">
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">The Operating and Anesthetic Reference Assistant (OARA): A fine-tuned large language model for resident teaching</h4>
-                    <p className="mb-2">This study aimed to fine-tune a large language model for domain-specific text generation in surgical and anesthesia residency education.</p>
-                    <p className="mb-2">This article includes the following:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>A fine-tuned version of a 7-billion parameter base model "Vicuna v1.5" trained on 266,342 lines of text</li>
-                      <li>Greater than 821 peer-reviewed documents</li>
-                      <li>Model evaluation with 150 surgical and anesthesia queries</li>
-                      <li>65.3% accuracy with excellence in surgical case-based tasks</li>
-                    </ul>
-                    <p className="mb-2">Impact: We provide a proof of concept.</p>
-                    <p>Published in <em>American Journal of Surgery</em> (Impact Factor: 2.7)</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Gurthrie E, Levy D. <a href="https://pubmed.ncbi.nlm.nih.gov/38365551/" target="_blank" className="text-blue-600 hover:underline">The Operating and Anesthetic Reference Assistant (OARA): A fine-tuned large language model for resident teaching.</a> <em>Am J Surg</em>. 2024 Aug.</li>
-              </Tooltip>
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Colorectal Cancer Surveillance Outcomes from an Institutional Longitudinal Cohort of Lynch Syndrome Patients</h4>
-                    <p className="mb-2">This study analyzed surveillance outcomes in a cohort of Lynch Syndrome patients to assess the effectiveness of current screening protocols.</p>
-                    <p className="mb-2">Key findings:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Colonoscopic surveillance detected 87% of colorectal cancers at early stages (I-II)</li>
-                      <li>Interval between surveillance significantly affected detection rates</li>
-                      <li>DNA mismatch repair mutation type correlated with cancer development risk</li>
-                      <li>Hispanic patients demonstrated unique surveillance compliance and outcome patterns</li>
-                    </ul>
-                    <p className="mb-2">Impact: These findings have informed updated surveillance guidelines for Lynch Syndrome patients, particularly addressing ethnically diverse populations.</p>
-                    <p>Published in <em>Frontiers in Oncology</em> (Impact Factor: 3.5)</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Reyes-Uribe L, Goyco D, Evans K, Kinnison J, Sepeda V, Weber D, Moskowitz J, Mork M, Taggart M, Thirumurthi S, Rodriguez-Bigas M, Lynch P, You Y.N, Vilar E. <a href="https://doi.org/10.3389/fonc.2023.1140908" target="_blank" className="text-blue-600 hover:underline">Colorectal Cancer Surveillance Outcomes from an Institutional Longitudinal Cohort of Lynch Syndrome Patients.</a> <em>Frontiers in Oncology</em>. 2023 Apr 11.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Reflections from a Trauma Bay</h4>
-                    <p className="mb-2">A personal narrative and ethical reflection on experiences in emergency medicine, focusing on moral distress and resilience.</p>
-                    <p className="mb-2">This article explores:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>The psychological impact of witnessing trauma on healthcare providers</li>
-                      <li>Mechanisms of processing moral distress in emergency settings</li>
-                      <li>The role of narrative and reflection in physician wellbeing</li>
-                      <li>Pedagogical implications for medical education</li>
-                    </ul>
-                    <p>Published in <em>Academic Emergency Medicine</em> (Impact Factor: 3.262)</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span> (2022). <a href="https://pubmed.ncbi.nlm.nih.gov/36445067/" target="_blank" className="text-blue-600 hover:underline">Reflections from a Trauma Bay.</a> <em>Academic Emergency Medicine</em>. 2022 Nov 29. doi: 10.1111/acem.14634.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">The Paradoxical Protective Effect of Immigration on Colon Cancer Survivals</h4>
-                    <p className="mb-2">This study investigated the relationship between immigration status and colon cancer outcomes using large-scale population data.</p>
-                    <p className="mb-2">Key findings:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>First-generation immigrants showed significantly better survival rates despite socioeconomic disadvantages</li>
-                      <li>This survival advantage decreased with successive generations</li>
-                      <li>The effect remained significant after controlling for age, stage at diagnosis, and treatment access</li>
-                      <li>Potential explanations include the "healthy immigrant effect" and dietary/lifestyle factors</li>
-                    </ul>
-                    <p>Published in <em>Journal of Surgical Research</em> (Impact Factor: 2.574)</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, et al. <a href="https://doi.org/10.1016/j.jss.2021.06.005" target="_blank" className="text-blue-600 hover:underline">The Paradoxical Protective Effect of Immigration on Colon Cancer Survivals.</a> <em>J Surg Res</em>. 2021 Jan 6. doi: 10.1016/j.jss.2021.06.005</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Intra-aortic Balloon Pump Placement in Coronary Artery Bypass Grafting Patients by Day of Admission</h4>
-                    <p className="mb-2">This retrospective study examined whether day of hospital admission influenced the timing of intra-aortic balloon pump (IABP) placement in CABG patients.</p>
-                    <p className="mb-2">Research highlights:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Analysis of 10,625 CABG patients who received preoperative IABP</li>
-                      <li>Weekend admissions were associated with delayed IABP placement</li>
-                      <li>Delayed placement correlated with increased postoperative complications</li>
-                      <li>The "weekend effect" was more pronounced in non-teaching hospitals</li>
-                    </ul>
-                    <p>Published in <em>Journal of Cardiothoracic Surgery</em> (Impact Factor: 1.737)</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Axtell A, Chang D, Melnitchouk S, Sundt TM 3rd, Fiedler AG. <a href="https://doi.org/10.1186/s13019-020-01259-z" target="_blank" className="text-blue-600 hover:underline">Intra-aortic balloon pump placement in coronary artery bypass grafting patients by day of admission.</a> <em>J Cardiothorac Surg</em>. 2020 Aug 14;15(1):219. doi: 10.1186/s13019-020-01259-z.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Does preoperative pharmacologic prophylaxis reduce the rate of venous thromboembolism in pancreatectomy patients?</h4>
-                    <p className="mb-2">A systematic review and meta-analysis examining the efficacy of preoperative venous thromboembolism (VTE) prophylaxis in pancreatic surgery.</p>
-                    <p className="mb-2">Major outcomes:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Analysis of 23 studies with 9,147 patients undergoing pancreatectomy</li>
-                      <li>Preoperative prophylaxis significantly reduced postoperative VTE events</li>
-                      <li>No significant increase in bleeding complications was observed</li>
-                      <li>Extended prophylaxis provided additional risk reduction for high-risk patients</li>
-                    </ul>
-                    <p>Published in <em>HPB</em>, the official journal of the International Hepato-Pancreato-Biliary Association (Impact Factor: 3.401)</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help">Fong ZV, Sell NM, Fernandez-Del Castillo C, <span className="font-medium">Del Carmen GA</span>, Ferrone CR, Chang DC, Warshaw AL, Polk HC Jr, Lillemoe KD, Qadan M. <a href="https://doi.org/10.1016/j.hpn.2019.10.2437" target="_blank" className="text-blue-600 hover:underline">Does preoperative pharmacologic prophylaxis reduce the rate of venous thromboembolism in pancreatectomy patients?</a> <em>HPB (Oxford)</em>. 2020 Jul;22(7):1020-1024. doi: 10.1016/j.hpn.2019.10.2437.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Does the Day of the Week Predict a Cesarean Section? A Statewide Analysis</h4>
-                    <p className="mb-2">This population-based study investigated temporal patterns in cesarean section rates using comprehensive statewide data.</p>
-                    <p className="mb-2">Key findings:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Analysis of 1.2 million deliveries across 49 hospitals</li>
-                      <li>Identified significant variations in C-section rates by day of the week</li>
-                      <li>Friday showed the highest elective C-section rate (22.6%)</li>
-                      <li>These patterns persisted after controlling for medical indications</li>
-                      <li>Hospital-level factors contributed significantly to the observed variations</li>
-                    </ul>
-                    <p>Published in <em>Journal of Surgical Research</em> (Impact Factor: 2.574)</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Stapleton S, Qadan M, Del Carmen MG, Chang D. <a href="https://doi.org/10.1016/j.jss.2019.07.027" target="_blank" className="text-blue-600 hover:underline">Does the Day of the Week Predict a Cesarean Section? A Statewide Analysis.</a> <em>J Surg Res</em>. 2020 Jan; 245:288-294. doi: 10.1016/j.jss.2019.07.027.</li>
-              </Tooltip>
-            </ul>
-          </div>
-          
-          <div className="mb-8">
-            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Humanities & Medical Narrative Publications</h3>
-            <ul className="space-y-4 text-sm text-gray-600 font-light">
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">To Choose the Self</h4>
-                    <p className="mb-2">A reflective narrative exploring the tensions between self-care and professional responsibilities in modern medicine.</p>
-                    <p className="mb-2">Key themes:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>The ethical dimensions of physician self-care</li>
-                      <li>Burnout as both a personal and systemic issue</li>
-                      <li>The false dichotomy between patient care and provider wellbeing</li>
-                      <li>Structural reforms needed in medical education and practice</li>
-                    </ul>
-                    <p>Published in <em>Human Ties Digest</em>, a journal dedicated to medical humanities and narrative medicine.</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span> (2023). <a href="https://humanties.me/2023/03/22/to-choose-the-self/" target="_blank" className="text-blue-600 hover:underline">To Choose the Self.</a> <em>Human Ties Digest</em>. 2023 Mar 22.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Hope in the Time of Covid</h4>
-                    <p className="mb-2">A personal essay examining the concept of hope during healthcare crises from both a clinical and philosophical perspective.</p>
-                    <p className="mb-2">Central themes:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>The evolving nature of hope throughout the pandemic</li>
-                      <li>Hope as both a clinical tool and a psychological necessity</li>
-                      <li>The ethical challenges of maintaining hope while being truthful</li>
-                      <li>Community resilience and collective hope during sustained crisis</li>
-                    </ul>
-                    <p>Published in <em>Human Ties Digest</em>, during the height of the pandemic's uncertainty</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span> (2022). <a href="https://humanties.me/2022/01/14/hope-in-the-time-of-covid/" target="_blank" className="text-blue-600 hover:underline">Hope in the Time of Covid.</a> <em>Human Ties Digest</em>. 2022 Jan 14.</li>
-              </Tooltip>
-            </ul>
-          </div>
-          
-          <div className="mb-8">
-            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Manuscripts Under Review</h3>
-            <ul className="space-y-4 text-sm text-gray-600 font-light">
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">A Property-Based Framework for Evaluating the Onset of Moral Status</h4>
-                    <p className="mb-2">This philosophical analysis proposes a novel framework for determining moral status based on emergent properties rather than categorical classifications.</p>
-                    <p className="mb-2">Key contributions:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Critically evaluates existing theories of moral status attribution</li>
-                      <li>Develops a graduated, property-based approach to moral consideration</li>
-                      <li>Applies the framework to contentious bioethical cases</li>
-                      <li>Addresses implications for clinical practice and policy development</li>
-                    </ul>
-                    <p>Currently under review at <em>Bioethics</em>, a leading journal in bioethical theory and analysis.</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>. A Property-Based Framework for Evaluating the Onset of Moral Status. <em>Bioethics</em>. 2025 Mar 12. Submitted.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Bridging the Communication Gap: An Analysis of Google Translate and GPT-4o in English to Spanish Translation in Neurology</h4>
-                    <p className="mb-2">This study evaluates the accuracy and clinical safety of automated translation tools in neurological care.</p>
-                    <p className="mb-2">Research methodology:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Analysis of 120 standard neurological terms and phrases</li>
-                      <li>Comparative assessment of Google Translate and GPT-4o against certified medical translators</li>
-                      <li>Evaluation by bilingual neurologists for clinical accuracy</li>
-                      <li>Identification of high-risk mistranslations and error patterns</li>
-                    </ul>
-                    <p>Submitted to <em>Patient Education and Counseling</em>, currently in the review process.</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Alonzo BR, Cruz G. Bridging the Communication Gap: An Analysis of Google Translate and GPT-4o in English to Spanish Translation in Neurology. <em>Patient Education and Counseling</em>. 2025 Feb 28. Submitted.</li>
-              </Tooltip>
-            </ul>
-          </div>
-          
-          <div className="mb-8">
-            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Conference Oral Presentations</h3>
-            <ul className="space-y-4 text-sm text-gray-600 font-light">
-              {/* Added ASC 2025 Presentation (Presented) */}
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Defining AI's Role in Medical Ethics: Fine-Tuning Language Models to Enhance Surgical Decision-Making</h4>
-                    <p className="mb-2">This study fine-tuned Meta's Llama 3.1 on diverse ethical scenarios to assess its ability to augment physician ethical decision-making and identify its inherent preferences.</p>
-                    <p className="mb-2">Methods:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Generated training data using GPT-4o, ensuring diverse ethical cases.</li>
-                      <li>Fine-tuned Llama 3.1 on this dataset.</li>
-                      <li>Assessed model recommendations (for/against RYGB for a high-risk patient) based on beneficence, non-maleficence, autonomy, and justice.</li>
-                    </ul>
-                    <p className="mb-2">Results: Model overwhelmingly recommended surgery (70%), primarily citing patient autonomy (39%), but showed reluctance to provide specific ethical guidelines in equivocal cases (18%).</p>
-                    <p className="mb-2">Conclusion: Demonstrates LLMs can generate ethical decisions aligned with current frameworks but require curated training and validation by ethicists.</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Mettetal E, Marshall G, Moncada-Ortega A. Defining AI's Role in Medical Ethics: Fine-Tuning Language Models to Enhance Surgical Decision-Making. <em>Annual Academic Surgical Congress</em>. 20th Annual Conference; 2025 Feb; Las Vegas, NV.</li>
-              </Tooltip>
+          The Operating and Anesthetic Reference Assistant (OARA): A Fine-Tuned Large Language Model for Resident Teaching.
+        </a>{' '}
+        <em>American Journal of Surgery</em>. 2024 Aug 23.
+      </>
+    ),
+    details: (
+      <div>
+        <p className="mb-2 text-sm text-gray-600">
+          Developed and evaluated a domain-specific large language model to augment surgical and anesthesia resident education,
+          demonstrating 65% accuracy across 150 scenario-based queries.
+        </p>
+        <ul className="list-disc pl-4 text-xs text-gray-500 space-y-1">
+          <li>Fine-tuned a 7B-parameter foundation model on 266,000+ lines of curated operative and anesthetic content.</li>
+          <li>Benchmarked performance on procedural planning, intraoperative decision-making, and anesthetic calculations.</li>
+        </ul>
+      </div>
+    ),
+  },
+  {
+    id: 'case-files-hematology',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>. Disseminated Intravascular Coagulopathy. In: Toy EC, Toy AL, eds.{' '}
+        <em>Case Files Hematology Body System</em>. New York: McGraw Hill Publishers. In Press.
+      </>
+    ),
+    details: (
+      <div>
+        <p className="text-sm text-gray-600">
+          Contributed a case-based chapter detailing the pathophysiology, diagnostic criteria, and management strategies for DIC
+          within McGraw Hill&apos;s flagship Case Files series.
+        </p>
+      </div>
+    ),
+  },
+  {
+    id: 'lynch-surveillance-2023',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Reyes-Uribe L, Goyco D, Evans K, Kinnison J, Sepeda V, Weber D, Moskowitz J,
+        Mork M, Taggart M, Thirumurthi S, Rodriguez-Bigas M, Lynch P, You YN, Vilar E. Colorectal Cancer Surveillance Outcomes
+        from an Institutional Longitudinal Cohort of Lynch Syndrome Patients. <em>Frontiers in Oncology</em>. 2023 Apr 11.
+      </>
+    ),
+    details: (
+      <div>
+        <p className="text-sm text-gray-600">
+          An institutional cohort analysis evaluating colorectal cancer surveillance outcomes for patients with Lynch Syndrome,
+          linking mismatch repair mutations to interval cancer risk.
+        </p>
+      </div>
+    ),
+  },
+  {
+    id: 'to-choose-the-self-2023',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span> (2023).{' '}
+        <a
+          href="https://humanties.me/2023/03/22/to-choose-the-self/"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          To Choose the Self.
+        </a>{' '}
+        <em>Human Ties Digest</em>. 2023 Mar 22.
+      </>
+    ),
+    details: (
+      <div>
+        <p className="text-sm text-gray-600">
+          Reflective narrative examining the interplay between self-compassion and clinical duty within medical training.
+        </p>
+      </div>
+    ),
+  },
+  {
+    id: 'reflections-trauma-2022',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span> (2022).{' '}
+        <a
+          href="https://pubmed.ncbi.nlm.nih.gov/36445067/"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          Reflections from a Trauma Bay.
+        </a>{' '}
+        <em>Academic Emergency Medicine</em>. 2022 Nov 29. doi: 10.1111/acem.14634.
+      </>
+    ),
+  },
+  {
+    id: 'hope-covid-2022',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span> (2022).{' '}
+        <a
+          href="https://humanties.me/2022/01/14/hope-in-the-time-of-covid/"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          Hope in the Time of Covid.
+        </a>{' '}
+        <em>Human Ties Digest</em>. 2022 Jan 14.
+      </>
+    ),
+  },
+  {
+    id: 'immigration-colon-cancer-2021',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, et al.{' '}
+        <a
+          href="https://doi.org/10.1016/j.jss.2021.06.005"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          The Paradoxical Protective Effect of Immigration on Colon Cancer Survivals.
+        </a>{' '}
+        <em>Journal of Surgical Research</em>. 2021 Jan 6.
+      </>
+    ),
+  },
+  {
+    id: 'iabp-2020',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Axtell A, Chang D, Melnitchouk S, Sundt TM 3rd, Fiedler AG.{' '}
+        <a
+          href="https://doi.org/10.1186/s13019-020-01259-z"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          Intra-aortic balloon pump placement in coronary artery bypass grafting patients by day of admission.
+        </a>{' '}
+        <em>Journal of Cardiothoracic Surgery</em>. 2020 Aug 14;15(1):219.
+      </>
+    ),
+  },
+  {
+    id: 'vte-pancreatectomy-2020',
+    citation: (
+      <>
+        Fong ZV, Sell NM, Fernandez-Del Castillo C, <span className="font-medium">Del Carmen GA</span>, Ferrone CR, Chang DC, Warshaw AL,
+        Polk HC Jr, Lillemoe KD, Qadan M.{' '}
+        <a
+          href="https://doi.org/10.1016/j.hpb.2019.10.2437"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          Does preoperative pharmacologic prophylaxis reduce the rate of venous thromboembolism in pancreatectomy patients?
+        </a>{' '}
+        <em>HPB (Oxford)</em>. 2020 Jul;22(7):1020-1024.
+      </>
+    ),
+  },
+  {
+    id: 'cesarean-weekday-2020',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Stapleton S, Qadan M, Del Carmen MG, Chang D.{' '}
+        <a
+          href="https://doi.org/10.1016/j.jss.2019.07.027"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          Does the Day of the Week Predict a Cesarean Section? A Statewide Analysis.
+        </a>{' '}
+        <em>Journal of Surgical Research</em>. 2020 Jan;245:288-294.
+      </>
+    ),
+  },
+  {
+    id: 'mental-health-issue-2017',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span> (2017).{' '}
+        <a
+          href="https://www.amazon.com/Mental-Health-Issue-Why-Matters/dp/1521327793"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          The Mental Health Issue: And Why It Matters.
+        </a>{' '}
+        Independently Published. ISBN: 1521327793.
+      </>
+    ),
+  },
+];
 
-              {/* Added ASC 2025 Presentation (Mentored) */}
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Linguistic Characteristics of Simulated Goals of Care Discussions and Implications for Residency Training</h4>
-                    <p className="mb-2">Utilized Microsoft Autogen with GPT-4 agents (Physician, Patient simulating emotions) to simulate Goals of Care (GOC) discussions for widely metastatic malignancy.</p>
-                    <p className="mb-2">Methods:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>50 simulations across 5 emotional states (anger, sadness, acceptance, denial, anxiety).</li>
-                      <li>Lexical analysis performed: message length, keyword frequency, readability (Flesch-Kincaid), named entities.</li>
-                    </ul>
-                    <p className="mb-2">Results: Average readability was 5th grade level. Keywords varied by emotional state (e.g., "fight" in acceptance, "symptoms" in denial). "Care", "support", "life", "time" were most frequent overall.</p>
-                    <p className="mb-2">Conclusion: Agentic AI shows promise for communication training. Future models need curation with real GOC transcripts for enhanced realism.</p>
-                    <p className="mt-3 italic text-xs">Note: Served as project mentor for this resident/student presentation.</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                 <li className="cursor-help">Mertz G*, Menon S*, Galbraith D, Krzesaj PK*, <span className="font-medium">Del Carmen GA</span>. Linguistic Characteristics of Simulated Goals of Care Discussions and Implications for Residency Training. <em>Annual Academic Surgical Congress</em>. 20th Annual Conference; 2025 Feb; Las Vegas, NV. (*Equal Contribution)</li>
-              </Tooltip>
+const manuscriptsInProgress: PublicationItem[] = [
+  {
+    id: 'moral-status-2025',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>. A Property-Based Framework for Evaluating the Onset of Moral Status.{' '}
+        <em>Bioethics</em>. Submitted October 2025.
+      </>
+    ),
+  },
+  {
+    id: 'translation-neurology-2025',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Alonzo BR, Cruz G. Bridging the Communication Gap: An Analysis of Google
+        Translate and GPT-4o in English to Spanish Translation in Neurology. <em>Patient Education and Counseling</em>. Submitted
+        February 2025.
+      </>
+    ),
+  },
+  {
+    id: 'immunological-landscape-2025',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Schmit S, Vilar E. A Review of the Immunological Landscape for Pre-Cancerous
+        Colorectal Lesions. Manuscript in progress.
+      </>
+    ),
+  },
+  {
+    id: 'bariatric-reddit-2025',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Patel D, Zaman JA. Pre-Operative Concerns and Post-Operative Satisfaction:
+        Comparing Attitudes Towards Bariatric Surgery and Medication Intervention for Weight Loss on Reddit. Manuscript in
+        progress.
+      </>
+    ),
+  },
+];
 
-              {/* Replaced placeholder/previous ASC 2024 with actual presentation (Mentored) */}
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Analyzing Readability and Sentiment of Patient Health Information Online for Whipple Procedures</h4>
-                    <p className="mb-2">Quantified readability, sentiment, and subjectivity of online resources for Whipple surgeries using Natural Language Processing (NLP).</p>
-                     <p className="mb-2">Methods:</p>
-                     <ul className="list-disc pl-4 mb-2">
-                       <li>Cross-sectional analysis of top 25 webpages (academic, journal, hospital, commercial, unspecified).</li>
-                       <li>Readability measured via Flesch-Kincaid, SMOG, Coleman-Liau, Gunning-Fog.</li>
-                       <li>Sentiment/subjectivity assessed using Python's TextBlob.</li>
-                     </ul>
-                     <p className="mb-2">Results: Mean readability exceeded recommended 6th-grade level across all indices. Journal articles (15.2) and academic sites (12.9) were particularly high. Sentiment was mildly positive, subjectivity moderate.</p>
-                     <p className="mb-2">Conclusion: Online health information for Whipple surgery is often inaccessible, potentially worsening disparities. NLP can help institutions improve materials.</p>
-                     <p className="mt-3 italic text-xs">Note: Served as project mentor for this resident/student presentation.</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help">Menon S*, Mertz G*, <span className="font-medium">Del Carmen GA</span>. Simulating Goals of Care Discussions with Language Models: Artificial Intelligence as an Adjunct to Physician Skill Training. <em>Annual Academic Surgical Congress</em>. 19th Annual Conference; 2024 Feb; Washington D.C., USA. (*Equal Contribution)</li>
-                {/* Citation updated based on second abstract provided for this topic */} 
-              </Tooltip>
+const oralPresentations: PublicationItem[] = [
+  {
+    id: 'asc-2025-ai-ethics',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>. Defining AI&apos;s Role in Medical Ethics: Fine-Tuning Language Models to Enhance
+        Surgical Decision-Making. <em>Annual Academic Surgical Congress</em>. 22nd Annual Conference; 2025 Feb 12; Las Vegas, NV.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2025-goals-of-care',
+    citation: (
+      <>
+        Menon SJ, Mertz G, <span className="font-medium">Del Carmen GA</span>. Simulating Goals of Care Discussions with Language Models:
+        Artificial Intelligence as an Adjunct to Physician Skill Training. <em>Annual Academic Surgical Congress</em>. 21st Annual
+        Conference; 2025 Feb 12; Las Vegas, NV.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2025-linguistic',
+    citation: (
+      <>
+        Mertz G, Menon SJ, Krzesaj PK, <span className="font-medium">Del Carmen GA</span>. Linguistic Characteristics of Simulated Goals of
+        Care Discussions and Implications for Residency Training. <em>Annual Academic Surgical Congress</em>. 20th Annual
+        Conference; 2025 Feb 12; Las Vegas, NV.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2024-whipple',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Chang DC. Reimagining Surgical Patient Materials: Natural Language Processing of
+        Online Education for Whipple Procedures. <em>Annual Academic Surgical Congress</em>. 19th Annual Conference; 2024 Feb 8;
+        Washington, D.C.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2023-ethics',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>. Natural Language Processing as a Tool for Ethical Consensus Analysis in Organ
+        Transplant Allocation. <em>Annual Academic Surgical Congress</em>. 18th Annual Conference; 2023 Feb 8; Houston, TX.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2020-ethics',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, et al. What is the Prevalent Ethical Recommendation in the Medical Literature? An
+        Algorithmic Approach. <em>Annual Academic Surgical Congress</em>. 15th Annual Conference; 2020 Feb 3-6; Orlando, FL.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2019-cesarean',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, et al. Does the Day of the Week Predict a Cesarean Section? A Statewide Analysis.
+        <em>Annual Academic Surgical Congress</em>. 14th Annual Conference; 2019 Feb 5-7; Houston, TX.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2019-iabp',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, et al. Pre-Op IABP Placement Rates in Coronary Artery Bypass Grafting Patients by Day of
+        Admission. <em>Annual Academic Surgical Congress</em>. 14th Annual Conference; 2019 Feb 5-7; Houston, TX.
+      </>
+    ),
+  },
+];
 
-              {/* Existing ASC 2023 Presentation */}
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">What is the Prevalent Ethical Recommendation in the Medical Literature? An Algorithmic Approach</h4>
-                    <p className="mb-2">This research presented a computational approach to identifying and analyzing ethical recommendations in medical publications.</p>
-                    <p className="mb-2">Methodology and findings:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Development of a machine learning algorithm to classify ethical recommendations</li>
-                      <li>Analysis of recommendations across 15 medical specialties</li>
-                      <li>Identification of variations in ethical frameworks between specialties</li>
-                      <li>Temporal trends in ethical reasoning over the past three decades</li>
-                    </ul>
-                    <p>Presented at the 15th Annual Academic Surgical Congress in Orlando, Florida</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, et al. What is the Prevalent Ethical Recommendation in the Medical Literature? An Algorithmic Approach. <em>Annual Academic Surgical Congress</em>. 15th Annual Conference; 2020 Feb; Orlando, FL.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Does the Day of the Week Predict a Cesarean Section? A Statewide Analysis</h4>
-                    <p className="mb-2">This presentation shared findings from a comprehensive analysis of temporal patterns in cesarean section rates.</p>
-                    <p className="mb-2">Key results presented:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Analysis of 1.2 million deliveries across Massachusetts hospitals</li>
-                      <li>Significant day-of-week variation in elective C-section rates</li>
-                      <li>Association between weekend staffing patterns and C-section decision-making</li>
-                      <li>Policy implications for standardizing obstetric care delivery</li>
-                    </ul>
-                    <p>Presented at the 14th Annual Academic Surgical Congress in Houston, Texas</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, et al. Does the Day of the Week Predict a Cesarean Section? A Statewide Analysis. <em>Annual Academic Surgical Congress</em>. 14th Annual Conference; 2019 Feb; Houston, TX.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Pre-Op IABP Placement Rates in Coronary Artery Bypass Grafting Patients by Day of Admission</h4>
-                    <p className="mb-2">This presentation explored temporal disparities in the use of intra-aortic balloon pumps for CABG patients.</p>
-                    <p className="mb-2">Research methodology:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Retrospective analysis of a national inpatient database</li>
-                      <li>Evaluation of weekend vs. weekday IABP placement timing</li>
-                      <li>Assessment of institutional factors affecting placement decisions</li>
-                      <li>Correlation between placement timing and patient outcomes</li>
-                    </ul>
-                    <p>Presented at the 14th Annual Academic Surgical Congress in Houston, Texas</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, et al. Pre-Op IABP Placement Rates in Coronary Artery Bypass Grafting Patients by Day of Admission. <em>Annual Academic Surgical Congress</em>. 14th Annual Conference; 2019 Feb; Houston, TX.</li>
-              </Tooltip>
-            </ul>
-          </div>
-          
-          <div>
-            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Conference Poster Presentations</h3>
-            <ul className="space-y-4 text-sm text-gray-600 font-light">
-              {/* Removed Whipple NLP poster as it was moved/updated to Oral Presentations */}
-              {/* <Tooltip ...> ... </Tooltip> */}
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Tackling Scientific Racism: Modifying the Critical Appraisal Skills Programme (CASP) Checklist to Advance Health Equity</h4>
-                    <p className="mb-2">This collaborative project introduced modifications to standard research appraisal tools to address scientific racism in medical literature.</p>
-                    <p className="mb-2">Key innovations:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Modified the Critical Appraisal Skills Programme (CASP) checklist to incorporate a health equity lens</li>
-                      <li>Added questions like "Is the use of 'race' meant to serve as a measure of socioeconomic status?" and "Can conclusions about 'race' be better explained by environmental influences?"</li>
-                      <li>Designed to empower medical students to identify and evaluate scientific racism in pre-clinical curriculum</li>
-                      <li>Aimed at reducing healthcare disparities by addressing biases in medical education content</li>
-                    </ul>
-                    <p>Presented at the 2023 Health Equity Research Summit at Baylor College of Medicine.</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, McCleary-Gaddy A. Tackling Scientific Racism: Modifying the Critical Appraisal Skills Programme (CASP) Checklist to Advance Health Equity. <em>Baylor College of Medicine. 2023 Health Equity Research Summit</em>; Houston, TX.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Natural Language Processing as a Tool for Ethical Consensus Analysis in Organ Transplant Allocation</h4>
-                    <p className="mb-2">This poster presentation demonstrated computational approaches to analyzing ethical frameworks in transplantation literature.</p>
-                    <p className="mb-2">Technical methodology:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Text corpus compilation from medical, ethical, and legal transplant literature</li>
-                      <li>Development of custom NLP algorithms for ethical argument extraction</li>
-                      <li>Network analysis of argument patterns and citation relationships</li>
-                      <li>Visualization of consensus evolution across medical specialties</li>
-                    </ul>
-                    <p>Presented at the 11th Annual Latino Medical Student Association Conference in Fort Worth, Texas</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>. Natural Language Processing as a Tool for Ethical Consensus Analysis in Organ Transplant Allocation. <em>Latino Medical Student Association</em>. 11th Annual Conference; 2023; Fort Worth, TX.</li>
-              </Tooltip>
-              
-              <Tooltip
-                content={
-                  <div>
-                    <h4 className="font-medium mb-2">Impact of Hispanic Ethnicity on Colorectal Cancer Surveillance Outcomes and Management in an Institutional Longitudinal Cohort of Lynch Syndrome Patients</h4>
-                    <p className="mb-2">This research investigated potential disparities in Lynch Syndrome management among Hispanic patients.</p>
-                    <p className="mb-2">Key findings:</p>
-                    <ul className="list-disc pl-4 mb-2">
-                      <li>Analysis of surveillance outcomes across ethnic groups in a Lynch Syndrome cohort</li>
-                      <li>Identification of differences in cancer detection timing and stage</li>
-                      <li>Examination of cultural and socioeconomic factors affecting surveillance adherence</li>
-                      <li>Recommendations for culturally-tailored genetic counseling approaches</li>
-                    </ul>
-                    <p>Presented at the MD Anderson Summer Experience research symposium in Houston, Texas</p>
-                  </div>
-                }
-                position="bottom"
-                width="max-w-md"
-              >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, et al. Impact of Hispanic Ethnicity on Colorectal Cancer Surveillance Outcomes and Management in an Institutional Longitudinal Cohort of Lynch Syndrome Patients. <em>MD Anderson Summer Experience</em>; 2021; Houston, TX.</li>
-              </Tooltip>
-            </ul>
-          </div>
+const oralUnderReview: PublicationItem[] = [
+  {
+    id: 'asc-2026-computer-vision',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Chen C, Shahbazov R. Benchmarking Robust Computer Vision Models: GPT&apos;s Vision
+        Capabilities in Radiological Interpretation of Chest X-Rays with Zero-Shot, One-Shot, and Few-Shot Learning. <em>Annual
+        Academic Surgical Congress</em>. 23rd Annual Conference. Accepted.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2026-implicit-bias',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Mohanraj D, John M, Malcom M, McKay S, Marrin A, Singh TP. Assessing Implicit Bias in the
+        Clinical Decision-Making of Large Language Models. <em>Annual Academic Surgical Congress</em>. 23rd Annual Conference.
+        Accepted.
+      </>
+    ),
+  },
+  {
+    id: 'sages-2026-bariatric',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Mohanraj D, John M, Malcom M, McKay S, Marrin A, Zaman JA. Pre-Operative Concerns and
+        Post-Operative Satisfaction: Comparing Attitudes Towards Bariatric Surgery and Medication Intervention for Weight Loss
+        on Reddit. <em>Society of American Gastrointestinal and Endoscopic Surgeons</em>. SAGES 2026. Under review.
+      </>
+    ),
+  },
+  {
+    id: 'sages-2026-marcus',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, Shukla D, Zaman J. Multimodal Agentic Retrieval for Clinical Utility and Synthesis (MARCUS):
+        A Retrieval Augmented Generation System for Residency Information Centralization. <em>SAGES Emerging Technology 2026</em>.
+        Pending submission.
+      </>
+    ),
+  },
+];
 
-          {/* Removed 'Manuscripts in Preparation' title and moved content to 'Research in Progress' section */}
-          {/* <div className="mb-8"> ... </div> */}
-        </section>
+const posterPresentations: PublicationItem[] = [
+  {
+    id: 'bcm-2023-whipple',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>. Using Natural Language Processing for Analysis of Readability, Sentiment, and Subjectivity of
+        Online Patient Education Materials for Whipple Surgery. <em>Baylor College of Medicine Health Equity Research Summit</em>.
+        16 May 2023; Houston, TX.
+      </>
+    ),
+  },
+  {
+    id: 'bcm-2023-casp',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, McCleary-Gaddy A. Tackling Scientific Racism: Modifying the Critical Appraisal Skills Programme
+        (CASP) Checklist to Advance Health Equity. <em>Baylor College of Medicine Health Equity Research Summit</em>. 16 May 2023;
+        Houston, TX.
+      </>
+    ),
+  },
+  {
+    id: 'lmsa-2023-ethics',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>. Natural Language Processing as a Tool for Ethical Consensus Analysis in Organ Transplant
+        Allocation. <em>Latino Medical Student Association National Conference</em>. 4 Feb 2023; Fort Worth, TX.
+      </>
+    ),
+  },
+  {
+    id: 'apa-2023-psychosis',
+    citation: (
+      <>
+        Burden J, <span className="font-medium">Del Carmen GA</span>, et al. Food and Drug Therapy – High-Dose Olanzapine and Family-Centered Exposure
+        Intervention for Complicated and Refractory Psychosis in an Adolescent Male. <em>American Psychiatric Association Annual
+        Meeting</em>. 20-24 May 2023; San Francisco, CA.
+      </>
+    ),
+  },
+  {
+    id: 'asts-2023-living-donor',
+    citation: (
+      <>
+        Menser T, Kolman J, Baek J, Taylor A, <span className="font-medium">Del Carmen GA</span>, Hobeika M. A Broad Review of Living Donor Kidney
+        Transplantation Interventions Among Racial and Ethnic Minority Populations. <em>American Society of Transplant Surgeons
+        Winter Symposium</em>. 12-15 Jan 2023; Miami, FL.
+      </>
+    ),
+  },
+  {
+    id: 'mdanderson-2021-lynch',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, et al. Impact of Hispanic Ethnicity on Colorectal Cancer Surveillance Outcomes and Management in
+        an Institutional Longitudinal Cohort of Lynch Syndrome Patients. <em>MD Anderson Summer Experience</em>. 30 Jul 2021;
+        Houston, TX.
+      </>
+    ),
+  },
+  {
+    id: 'harvard-2019-pancreatectomy',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, et al. Does Preoperative Pharmacologic Prophylaxis Reduce the Rate of Venous Thromboembolism in
+        Pancreatectomy Patients? <em>Harvard Surgery Research Day</em>. 9 Mar 2019; Boston, MA.
+      </>
+    ),
+  },
+  {
+    id: 'mgh-2018-cesarean',
+    citation: (
+      <>
+        <span className="font-medium">Del Carmen GA</span>, et al. Does the Day of the Week Predict a Cesarean Section? A Statewide Analysis. <em>Massachusetts
+        General Hospital Clinical Research Day</em>. 4 Oct 2018; Boston, MA.
+      </>
+    ),
+  },
+];
+
+const academicConferences: PublicationItem[] = [
+  {
+    id: 'asc-2025',
+    citation: (
+      <>
+        <span className="font-medium">20th Annual Academic Surgical Congress</span> — February 2025. Accepted submissions included Defining AI&apos;s Role in
+        Medical Ethics, Simulating Goals of Care Discussions with Language Models, and Linguistic Characteristics of Simulated
+        Goals of Care Discussions.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2024',
+    citation: (
+      <>
+        <span className="font-medium">19th Annual Academic Surgical Congress</span> — February 2024. Accepted submission: Reimagining Surgical Patient
+        Materials: Natural Language Processing of Online Education for Whipple Procedures.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2023',
+    citation: (
+      <>
+        <span className="font-medium">18th Annual Academic Surgical Congress</span> — February 2023. Accepted submission: Natural Language Processing as a
+        Tool for Ethical Consensus Analysis in Organ Transplant Allocation.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2020',
+    citation: (
+      <>
+        <span className="font-medium">15th Annual Academic Surgical Congress</span> — February 2020. Accepted submission: What is the Prevalent Ethical
+        Recommendation in the Medical Literature? An Algorithmic Approach.
+      </>
+    ),
+  },
+  {
+    id: 'asc-2019',
+    citation: (
+      <>
+        <span className="font-medium">14th Annual Academic Surgical Congress</span> — February 2019. Accepted submissions: Does the Day of the Week Predict a
+        Cesarean Section? and Pre-Op IABP Placement Rates in Coronary Artery Bypass Grafting Patients by Day of Admission.
+      </>
+    ),
+  },
+  {
+    id: 'philosophy-2018',
+    citation: (
+      <>
+        <span className="font-medium">Undergraduate Philosophy Conferences (2018)</span> — North Shore Undergraduate Philosophy Conference, Pacific University,
+        Boston-Area Undergraduate Philosophy Conference at Emmanuel College, 7th Annual CUNY Undergraduate Philosophy Conference,
+        and the Joint Meeting of the South Carolina and North Carolina Philosophical Societies. Presented analyses on identity,
+        causality, and time travel.
+      </>
+    ),
+  },
+  {
+    id: 'pacific-2017',
+    citation: (
+      <>
+        <span className="font-medium">Pacific University Undergraduate Philosophy Conference</span> — April 2017. Presented &ldquo;A Multiple Causal Model of
+        Identity – A Critique of Parfit.&rdquo;
+      </>
+    ),
+  },
+];
+
+const renderPublicationList = (items: PublicationItem[]) => (
+  <ul className="space-y-4 text-sm text-gray-600 font-light">
+    {items.map((item) =>
+      item.details ? (
+        <Tooltip key={item.id} content={item.details} position="bottom" width="max-w-md">
+          <li className="cursor-help">{item.citation}</li>
+        </Tooltip>
+      ) : (
+        <li key={item.id}>{item.citation}</li>
+      )
+    )}
+  </ul>
+);
+
+const PublicationsSection = ({ isVisible }: SectionProps) => (
+  <section
+    id="publications"
+    className={`mb-16 transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
+  >
+    <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">
+      Publications & Scholarly Activity
+      <span className="ml-2 text-xs text-gray-400 font-light inline-flex items-center">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-3 w-3 mr-1"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        Hover for details
+      </span>
+    </h2>
+
+    <div className="space-y-10">
+      <div>
+        <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Original Publications & Book Chapters</h3>
+        {renderPublicationList(originalPublications)}
+      </div>
+
+      <div>
+        <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Manuscripts In Progress or Under Review</h3>
+        {renderPublicationList(manuscriptsInProgress)}
+      </div>
+
+      <div>
+        <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Abstracts Accepted for Oral Presentation</h3>
+        {renderPublicationList(oralPresentations)}
+      </div>
+
+      <div>
+        <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Abstracts Under Consideration</h3>
+        {renderPublicationList(oralUnderReview)}
+      </div>
+
+      <div>
+        <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Abstracts Accepted for Poster Presentation</h3>
+        {renderPublicationList(posterPresentations)}
+      </div>
+
+      <div>
+        <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Academic Conferences</h3>
+        {renderPublicationList(academicConferences)}
+      </div>
+    </div>
+  </section>
 );
 
 export default PublicationsSection;

--- a/src/components/sections/ResearchSection.tsx
+++ b/src/components/sections/ResearchSection.tsx
@@ -10,40 +10,57 @@ const ResearchSection = ({ isVisible }: SectionProps) => (
           <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Research Experience</h2>
           <div className="space-y-8">
             <div>
-              <h3 className="text-base font-medium text-gray-900">Vilar Lab, MD Anderson Cancer Center</h3>
-              <p className="text-sm text-gray-500 mt-1">Research Associate | 2021 – 2024</p>
+              <h3 className="text-base font-medium text-gray-900">Vilar Lab, MD Anderson Cancer Center — Houston, TX</h3>
+              <p className="text-sm text-gray-500 mt-1">Research Fellow | June 2021 – June 2024</p>
               <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
-                <li>• Performed research on inherited colorectal cancer syndromes</li>
-                <li>• Analyzed DNA mismatch repair mutations in a Lynch Syndrome patient cohort</li>
-                <li>• Conducted comprehensive scoping review on immunological research in colorectal cancer</li>
+                <li>• Advanced hypotheses on inherited colorectal cancer syndromes through multi-site collaboration.</li>
+                <li>• Analyzed DNA mismatch repair mutations in a longitudinal Lynch Syndrome cohort to inform surveillance pathways.</li>
+                <li>• Led a scoping review of the immunologic landscape of colorectal neoplasia to surface knowledge gaps.</li>
               </ul>
             </div>
 
             <div>
-              <h3 className="text-base font-medium text-gray-900">Transplant in Outcomes Research, Mayo Clinic – Jacksonville</h3>
-              <p className="text-sm text-gray-500 mt-1">Research Associate | 2021 – Present</p>
+              <h3 className="text-base font-medium text-gray-900">Transplant in Outcomes Research, Mayo Clinic — Jacksonville, FL (Remote)</h3>
+              <p className="text-sm text-gray-500 mt-1">Research Associate | June 2021 – July 2024</p>
               <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
-                <li>• Investigated racial and ethnic disparities in living donor kidney transplantation access</li>
-                <li>• Communicated research findings through abstracts, posters, and manuscripts</li>
+                <li>• Investigated racial and ethnic disparities in living donor kidney transplantation access via systematic review.</li>
+                <li>• Drafted and refined abstracts, posters, and manuscripts communicating opportunities for equitable interventions.</li>
               </ul>
             </div>
 
             <div>
-              <h3 className="text-base font-medium text-gray-900">Internal Medicine Lab (Haas Lab), Mass General Hospital</h3>
-              <p className="text-sm text-gray-500 mt-1">Research Assistant | 2019 – 2020</p>
+              <h3 className="text-base font-medium text-gray-900">Department of Internal Medicine, Massachusetts General Hospital — Boston, MA</h3>
+              <p className="text-sm text-gray-500 mt-1">Clinical Research Assistant | June 2019 – June 2020</p>
               <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
-                <li>• Focused on cervical cancer screening pathways and identifying points of care breakdown</li>
-                <li>• Conducted qualitative/quantitative stakeholder analyses (pathologists, primary care physicians)</li>
-                <li>• Performed large-scale chart reviews to inform pathway optimization</li>
+                <li>• Coordinated multi-site cervical cancer screening investigations across MGH, UT Southwestern, and Kaiser Permanente.</li>
+                <li>• Led data collection, cleaning, and statistical analyses to harmonize screening pathways across institutions.</li>
               </ul>
             </div>
 
             <div>
-              <h3 className="text-base font-medium text-gray-900">Codman Center for Clinical Effectiveness, Mass General Hospital</h3>
-              <p className="text-sm text-gray-500 mt-1">Research Assistant | 2017 – 2019</p>
+              <h3 className="text-base font-medium text-gray-900">Codman Center for Clinical Effectiveness, Massachusetts General Hospital — Boston, MA</h3>
+              <p className="text-sm text-gray-500 mt-1">Clinical Research Assistant | June 2017 – May 2019</p>
               <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
-                <li>• Applied statistical techniques using STATA to analyze statewide datasets</li>
-                <li>• Authored research manuscripts for medical and academic journals</li>
+                <li>• Applied STATA-based analytics on statewide datasets to evaluate cardiothoracic and obstetric outcomes.</li>
+                <li>• Authored, revised, and submitted peer-reviewed manuscripts while facilitating cross-specialty collaboration.</li>
+              </ul>
+            </div>
+
+            <div>
+              <h3 className="text-base font-medium text-gray-900">New England Baptist Hospital — Boston, MA</h3>
+              <p className="text-sm text-gray-500 mt-1">Research Assistant | March 2018 – May 2019</p>
+              <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                <li>• Digitized longitudinal orthopedic records into REDCap to streamline institutional outcomes tracking.</li>
+                <li>• Built databases enabling year-over-year quality improvement analysis for joint replacement patients.</li>
+              </ul>
+            </div>
+
+            <div>
+              <h3 className="text-base font-medium text-gray-900">Aging, Culture, and Cognition Laboratory, Brandeis University — Waltham, MA</h3>
+              <p className="text-sm text-gray-500 mt-1">Undergraduate Researcher | August 2016 – May 2019</p>
+              <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                <li>• Conducted interview-based studies examining memory formation, deception, and cultural context.</li>
+                <li>• Facilitated participant engagement and data collection to support cross-cultural cognition research.</li>
               </ul>
             </div>
           </div>

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -17,7 +17,11 @@ const SkillsSection = ({ isVisible }: SectionProps) => (
               <span className="text-sm text-gray-600 font-light">EPIC</span>
               <span className="text-sm text-gray-600 font-light">Python</span>
               <span className="text-sm text-gray-600 font-light">Microsoft Access</span>
-              <span className="text-sm text-gray-600 font-light">IRB Submissions</span>
+              <span className="text-sm text-gray-600 font-light">IRB submission & amendments</span>
+              <span className="text-sm text-gray-600 font-light">SwiftUI</span>
+              <span className="text-sm text-gray-600 font-light">Xcode</span>
+              <span className="text-sm text-gray-600 font-light">HTML</span>
+              <span className="text-sm text-gray-600 font-light">Java (familiarity)</span>
             </div>
           </div>
           
@@ -34,9 +38,17 @@ const SkillsSection = ({ isVisible }: SectionProps) => (
           <div>
             <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Interests</h3>
             <ul className="text-sm text-gray-600 font-light space-y-1">
-              <li>• Creative writing: Self-published science fiction and horror fiction</li>
-              <li>• Reading: Horror fiction and philosophical literature</li>
-              <li>• Music production: Compositions using FL Studio and MIDI synthesizers</li>
+              <li>
+                • Creative writing: Written and self-published science fiction and horror fiction stories, partnering with
+                narrators who broadcast to wide online audiences.
+              </li>
+              <li>
+                • Reading: Horror fiction (especially Stephen King) and existentialist philosophy including Sartre, Camus, and
+                Epictetus.
+              </li>
+              <li>
+                • Music production: Compose low-fidelity instrumentals using FL Studio and MIDI synthesizers.
+              </li>
             </ul>
           </div>
         </section>

--- a/src/data/futureProjects.ts
+++ b/src/data/futureProjects.ts
@@ -1,87 +1,101 @@
 export const futureProjectsData = [
   {
-    title: 'NLP Analysis of Online Bariatric & Weight Loss Communities (Reddit)',
+    title: 'A Property-Based Framework for Evaluating the Onset of Moral Status',
     summary:
-      'Comparing patient experiences and attitudes towards bariatric surgery vs. weight loss medication using NLP on Reddit data.',
+      'Developing a philosophical framework that assesses when moral status emerges using property-based criteria instead of categorical thresholds.',
     description:
-      'Utilizing Natural Language Processing (NLP) and Machine Learning (ML) to analyze user-generated content on Reddit communities (e.g., r/bariatricsurgery, r/Ozempic) dedicated to Roux-en-Y gastric bypass, sleeve gastrectomy, and semaglutide.',
+      'Extends contemporary bioethical discourse by formalizing a property-based approach to moral status, scrutinizing classical conceptions such as the Conception view and mapping implications for policy.',
     components: [
-      'Large-scale data extraction and preprocessing from relevant subreddits.',
-      'Application of NLP for sentiment analysis, subjectivity scoring, and topic modeling (LDA).',
-      'Comparative analysis of discussions surrounding surgical vs. pharmacological weight loss.',
-      'Identification of frequently discussed adverse effects, patient concerns (pre/post-intervention), and themes of peer support.',
+      'Defines necessary and sufficient conditions that any proposed property must meet to confer moral status.',
+      'Applies the framework to fertilization, brain development, and other milestone events in clinical ethics debates.',
+      'Explores downstream implications for abortion, organ allocation, and end-of-life decision-making.',
+      'Situates the proposal within broader moral philosophy and bioethics literature to anticipate critiques.',
     ],
-    status: 'Initial analyses complete. Manuscript in final preparation stages.',
+    status: 'Manuscript submitted to Bioethics (October 2025).',
   },
   {
-    title: 'Accuracy of AI Translation Tools in Spanish Neurology',
+    title: 'Bridging the Communication Gap: Evaluating Google Translate and GPT-4o in Neurology',
     summary:
-      'Comparing Google Translate vs. GPT-4o for translating English neurology questions to Spanish for patients with limited English proficiency.',
+      'Head-to-head comparison of automated translation tools for English-to-Spanish neurologic assessments among patients with limited English proficiency.',
     description:
-      'Comparative analysis evaluating the accuracy and clinical appropriateness of AI translation tools (Google Translate and GPT-4o) for common English-to-Spanish clinical questions used in neurologic assessments.',
+      'Assesses the safety and clinical fidelity of AI-driven translation by benchmarking Google Translate and GPT-4o outputs against certified medical interpreters for common neurology encounters.',
     components: [
-      'Evaluation of 120+ standard neurological phrases translated by Google Translate and GPT-4o.',
-      'Assessment by bilingual neurologists for clinical accuracy and potential risk.',
-      'Analysis of consistency, formality (usted vs. tú), and error patterns.',
-      'Calculation of inter-rater reliability (PABAK scores).',
+      'Curated corpus of 120+ neurological phrases spanning examination instructions, counseling, and informed consent.',
+      'Dual-review by bilingual neurologists evaluating accuracy, register (usted vs. tú), and clinical risk.',
+      'Error taxonomy mapping mistranslations to potential patient safety hazards.',
+      'Recommendations for institutional deployment of translation support in neurology clinics.',
     ],
-    status: 'Manuscript submitted.',
+    status: 'Submitted to Patient Education and Counseling (February 2025) and currently under review.',
   },
   {
-    title: 'Property-Based Framework for Moral Status Onset',
+    title: 'A Review of the Immunological Landscape for Pre-Cancerous Colorectal Lesions',
     summary:
-      'Philosophical analysis proposing and applying a framework to evaluate claims about the beginning of moral status.',
+      'Comprehensive scoping review of immunological mechanisms driving progression from precursor lesions to colorectal malignancy.',
     description:
-      'Philosophical essay proposing a novel framework to assess claims about when moral status begins, critically evaluating the “Conception view” often used in abortion ethics debates.',
+      'Synthesizes multi-omic and translational research to map the immune microenvironment of pre-cancerous colorectal lesions, highlighting opportunities for chemoprevention and targeted surveillance.',
     components: [
-      'Defines three necessary conditions (Antecedent, Shared, Necessity/Sufficiency) for a property P to establish moral onset.',
-      'Analyzes candidates for P (e.g., genetic uniqueness, causal trajectory) under the Conception view.',
-      'Argues fertilization fails to meet the criteria, challenging its designation as the definitive point of moral onset.',
-      'Applies the framework to other bioethical dilemmas (e.g., brain death).',
+      'Systematic extraction of immunologic markers implicated in Lynch Syndrome and sporadic colorectal neoplasia.',
+      'Comparison of innate and adaptive immune responses across lesion types and disease stages.',
+      'Identification of therapeutic targets and gaps ripe for translational investigation.',
+      'Roadmap for integrating immunoprofiling into longitudinal surveillance protocols.',
     ],
-    status: 'Manuscript submitted.',
+    status: 'Literature synthesis in progress; manuscript drafting underway.',
   },
   {
-    title: 'Implicit Bias Assessment in Clinical LLMs',
+    title: 'Pre-Operative Concerns and Post-Operative Satisfaction: Bariatric Surgery vs. Medication for Weight Loss on Reddit',
     summary:
-      'Evaluating if LLMs (GPT-4o) show bias in responses to clinical vignettes based on patient demographics.',
+      'Natural language processing analysis of online communities discussing bariatric surgery compared with pharmacologic weight-loss interventions.',
     description:
-      'Investigates whether a widely used LLM (GPT-4o) exhibits implicit biases when responding to clinical vignettes with varying patient characteristics (race, gender, socioeconomic status).',
+      'Leverages Reddit discourse to understand patient expectations and satisfaction across surgical and medical weight-loss pathways, informing patient education and shared decision-making.',
     components: [
-      'Development of structured clinical vignettes (Base, Bias, Benign variations) across different specialties.',
-      'Analysis of LLM responses using API calls under different determinism settings (temperature 0.2 vs. 0.8).',
-      'Qualitative and quantitative assessment of response variations linked to demographic cues.',
-      'Comparison with human clinician responses (planned).',
+      'Dataset construction from subreddit communities focused on bariatric surgery and GLP-1 medications.',
+      'Sentiment, subjectivity, and topic modeling to differentiate pre-operative concerns and post-intervention reflections.',
+      'Comparative analysis of perceived risks, support structures, and satisfaction trajectories.',
+      'Alignment of qualitative insights with emerging clinical trial data to contextualize patient narratives.',
     ],
-    status: 'Vignette development complete. Initial LLM response data collected. Analysis ongoing.',
+    status: 'Manuscript in progress; abstract under review for SAGES 2026.',
   },
   {
-    title: 'Ethical Frameworks for Autonomous AI in Healthcare',
+    title: 'Benchmarking Robust Computer Vision Models for Radiological Interpretation',
     summary:
-      'Investigating moral complexities, accountability, and empathy concerning autonomous AI in clinical decision-making.',
+      'Evaluating GPT-4o Vision and comparator models on chest X-ray interpretation using zero-shot, one-shot, and few-shot paradigms.',
     description:
-      'Ethical analysis exploring the challenges of integrating autonomous AI into healthcare, focusing on accountability, empathy, and patient-centered values.',
+      'Benchmarks multimodal large language models against established radiology datasets to characterize diagnostic accuracy, calibration, and failure modes in thoracic imaging.',
     components: [
-      'Examination of AI alignment with core medical ethics principles (autonomy, beneficence, etc.).',
-      'Analysis of the “many hands” problem and responsibility gaps for AI errors.',
-      'Discussion of simulated vs. genuine AI empathy and its ethical implications.',
-      'Development of policy and practice recommendations for responsible AI adoption.',
+      'VinDr-CXR dataset curation with balanced representation of common thoracic pathologies.',
+      'Prompt engineering experiments testing varying context windows and clinical histories.',
+      'Performance comparison across zero/one/few-shot configurations with detailed error analysis.',
+      'Framework for future deployment guidelines in surgical and critical care settings.',
     ],
-    status: 'Literature review and conceptual framework development ongoing. Preparing commentary/perspective piece.',
+    status: 'Accepted for oral presentation at the 23rd Annual Academic Surgical Congress (2026).',
   },
   {
-    title: 'Benchmarking Computer Vision Models in Radiology (CXR)',
+    title: 'Assessing Implicit Bias in the Clinical Decision-Making of Large Language Models',
     summary:
-      'Evaluating GPT-4oV’s diagnostic performance on chest X-rays using zero/one/few-shot learning.',
+      'Interrogating GPT-4o clinical recommendations across diverse patient demographics to surface implicit bias.',
     description:
-      'Evaluates the diagnostic performance of OpenAI’s GPT-4 Vision (GPT-4oV) model on interpreting chest X-rays (CXRs) using the VinDr-CXR dataset.',
+      'Constructs structured clinical vignettes with demographic variations to evaluate how stochasticity and prompt design influence AI-generated care plans.',
     components: [
-      'Systematic testing using OpenAI’s API under zero-shot, one-shot (with normal CXR comparison), and contextual learning (with clinical history) conditions.',
-      'Calculation of key performance metrics (accuracy, recall, precision, F1, NPV).',
-      'Analysis across different pathologies vs. radiologist consensus.',
-      'Prompt engineering experiments to optimize performance.',
+      'Creation of baseline, bias-testing, and benign vignettes across high-yield surgical scenarios.',
+      'Comparison of deterministic and higher-temperature outputs to assess variability and bias expression.',
+      'Qualitative review of safety-critical deviations and recommendations for guardrail development.',
+      'Planned comparison against resident and attending surgeon responses for contextual benchmarking.',
     ],
-    status: 'Data acquisition and preprocessing complete. API integration developed. Main experimental runs in progress.',
+    status: 'Accepted for oral presentation at the 23rd Annual Academic Surgical Congress (2026).',
+  },
+  {
+    title: 'Multimodal Agentic Retrieval for Clinical Utility and Synthesis (MARCUS)',
+    summary:
+      'Designing a retrieval-augmented generation system to centralize residency information and streamline onboarding.',
+    description:
+      'Combines structured program data, institutional policies, and resident-generated knowledge into a multimodal assistant that reduces onboarding friction and preserves institutional memory.',
+    components: [
+      'Hybrid knowledge graph linking documents, videos, and workflows relevant to surgical residency training.',
+      'Agentic orchestration pipeline coordinating retrieval, synthesis, and recommendation modules.',
+      'Evaluation rubric measuring accuracy, timeliness, and perceived utility among resident beta testers.',
+      'Deployment roadmap aligned with institutional governance and data privacy requirements.',
+    ],
+    status: 'Manuscript in development; abstract pending submission to SAGES Emerging Technology 2026.',
   },
 ];
 

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,4 +1,5 @@
 export const navSections = [
+  { id: 'current', label: 'Current' },
   { id: 'education', label: 'Education' },
   { id: 'about', label: 'About' },
   { id: 'publications', label: 'Publications' },
@@ -7,7 +8,7 @@ export const navSections = [
   { id: 'experience', label: 'Experience' },
   { id: 'skills', label: 'Skills' },
   { id: 'programming', label: 'Programming' },
-  { id: 'future', label: 'Future' },
+  { id: 'future', label: 'In Progress' },
   { id: 'contact', label: 'Contact' }
 ] as const;
 


### PR DESCRIPTION
## Summary
- add a current position and objective section with updated contact information
- refresh education, research, leadership, programming, and publications content to mirror the 2025 CV
- update in-progress research data, skills, and the interactive timeline for new projects

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690cb357cb9c8323bca8778e04dd584e)