### PR TITLE
Refresh CV sections and content

### DIFF
--- a/src/components/CVWebsite.tsx
+++ b/src/components/CVWebsite.tsx
@@ -4,6 +4,7 @@ import Navigation from './layout/Navigation';
 import Footer from './layout/Footer';
 import TimelineModal from './layout/TimelineModal';
 import EducationSection from './sections/EducationSection';
+import LicensureSection from './sections/LicensureSection';
 import AboutSection from './sections/AboutSection';
 import PublicationsSection from './sections/PublicationsSection';
 import ResearchSection from './sections/ResearchSection';
@@ -97,6 +98,7 @@ const CVWebsite = () => {
 
       <main className="max-w-4xl mx-auto px-6 py-12">
         <EducationSection isVisible={isSectionVisible('education')} />
+        <LicensureSection isVisible={isSectionVisible('licensure')} />
         <AboutSection isVisible={isSectionVisible('about')} />
         <PublicationsSection isVisible={isSectionVisible('publications')} />
         <ResearchSection isVisible={isSectionVisible('research')} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -9,6 +9,7 @@ const Header = () => (
           <p className="text-sm text-gray-500 font-light">
             General Surgery Resident (PGY-1) — Albany Medical Center | Expected Class of 2029
           </p>
+          <p className="text-xs text-gray-400 font-light mt-1">Last updated: November 2025</p>
         </div>
       </div>
       <div>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -7,8 +7,9 @@ interface NavigationProps {
 }
 
 const Navigation = ({ activeSection, sections, onNavigate }: NavigationProps) => {
-  const left = sections.slice(0, 5);
-  const right = sections.slice(5);
+  const midpoint = Math.ceil(sections.length / 2);
+  const left = sections.slice(0, midpoint);
+  const right = sections.slice(midpoint);
 
   const renderLink = (section: NavSection) => (
     <li key={section.id} className="mr-4 md:mr-5 last:mr-0">

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -9,7 +9,7 @@ const AboutSection = ({ isVisible }: SectionProps) => (
   >
     <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">About</h2>
     <p className="text-gray-600 leading-relaxed font-light">
-      I am a surgical resident deeply committed to advancing patient-centered care through surgical excellence and medical ethics, with a strong dedication to reducing disparities in healthcare quality and access. My interests include developing, refining, and promoting the responsible adoption of artificial intelligence tools to augment patient-centered care and improve clinical outcomes. Passionate about the ethical integration of AI in medicine, I aim to ensure these technologies enhance patient experiences without compromising humanistic care. My professional aspiration is to actively contribute to a collaborative, academically rigorous environment that prioritizes innovation, equitable healthcare, and continuous progress in surgery and medical education.
+      General surgery resident at Albany Medical Center pursuing a career in academic surgical oncology, with a focus on translational research, clinical trials, and surgical outcomes in colorectal and pancreatic disease. Committed to patient-centered care, ethical and evidence-based decision-making, and reducing disparities in health quality and access through leadership and education.
     </p>
   </section>
 );

--- a/src/components/sections/LicensureSection.tsx
+++ b/src/components/sections/LicensureSection.tsx
@@ -1,0 +1,39 @@
+interface SectionProps {
+  isVisible: boolean;
+}
+
+const LicensureSection = ({ isVisible }: SectionProps) => (
+  <section
+    id="licensure"
+    className={`mb-16 transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
+  >
+    <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">
+      Licensure & Certifications
+    </h2>
+    <ul className="list-disc pl-6 space-y-2 text-sm text-gray-600 font-light">
+      <li>
+        <span className="font-medium text-gray-800">New York Medical License</span> – Active (2024 – Present)
+      </li>
+      <li>
+        <span className="font-medium text-gray-800">USMLE Step 1</span> – Passed
+      </li>
+      <li>
+        <span className="font-medium text-gray-800">USMLE Step 2 CK</span> – Passed
+      </li>
+      <li>
+        <span className="font-medium text-gray-800">USMLE Step 3</span> – Planned for 2025
+      </li>
+      <li>
+        <span className="font-medium text-gray-800">Advanced Cardiovascular Life Support (ACLS)</span> – Expires October 2026
+      </li>
+      <li>
+        <span className="font-medium text-gray-800">Basic Life Support (BLS)</span> – Expires October 2026
+      </li>
+      <li>
+        <span className="font-medium text-gray-800">Advanced Trauma Life Support (ATLS)</span> – Expires April 2027
+      </li>
+    </ul>
+  </section>
+);
+
+export default LicensureSection;

--- a/src/components/sections/ProgrammingSection.tsx
+++ b/src/components/sections/ProgrammingSection.tsx
@@ -1,138 +1,72 @@
-import Tooltip from '../Tooltip';
-
 interface SectionProps {
   isVisible: boolean;
 }
 
+const projects = [
+  {
+    title: 'Trauma Practice Management Guidelines App',
+    role: 'Creator & Developer — October 2025',
+    summary:
+      "Centralizes Albany Medical Center's trauma practice management guidelines into a single, searchable, offline-capable SwiftUI app for quick bedside retrieval.",
+    highlights: [
+      'Structured every guideline section for tap-through, on-device access to airway, transfusion, and procedure algorithms.',
+      'Implements robust search, bookmarking, and recently-viewed states to speed up trauma bay decision-making.',
+      'Built with SwiftUI, Xcode, and institution-sourced guidelines in partnership with Dr. Kurt Edwards.',
+    ],
+  },
+  {
+    title: 'DrainBow',
+    role: 'Creator & Developer — November 2025',
+    summary:
+      'iOS app that captures bedside photos of drain output, performs on-device color detection, and logs volume trends for each drain.',
+    highlights: [
+      'Automates RGB color capture to produce a “rainbow” visualization of drain color changes alongside volume logs.',
+      'Stores structured, local-first data models that can be exported for team handoffs or registry upload.',
+      'SwiftUI interface optimized for gloved, one-handed use with secure photo storage and PHI-free exports.',
+    ],
+  },
+  {
+    title: 'Multimodal Agentic Retrieval for Clinical Utility and Synthesis (MARCUS)',
+    role: 'Concept Lead & Developer — 2024 – Present',
+    summary:
+      'Retrieval-augmented clinical assistant centralizing residency curricula, institutional policies, and service protocols in a single searchable interface.',
+    highlights: [
+      'Tenant-aware architecture enforces role-specific permissions across services and training levels.',
+      'Pipelines emphasize citation fidelity, versioning, and audit logs for every synthesized response.',
+      'Combines vector retrieval, structured metadata search, and lightweight agent workflows for multimodal content.',
+    ],
+  },
+];
+
 const ProgrammingSection = ({ isVisible }: SectionProps) => (
   <section
-          id="programming"
-          className={`mb-16 transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
-        >
-          <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Programming Projects & Initiatives
-            <span className="ml-2 text-xs text-gray-400 font-light inline-flex items-center">
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              Hover for details
-            </span>
-          </h2>
-
-          <div className="flex items-center mb-5">
-            <a href="https://github.com/gdelcarmen" target="_blank" rel="noopener noreferrer" className="text-gray-700 hover:text-gray-900 transition-colors mr-4">
-              <svg className="h-6 w-6 inline-block mr-2" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-              </svg>
-              GitHub Profile
-            </a>
-            {/* Consider adding LinkedIn or other relevant profiles */}
+    id="programming"
+    className={`mb-16 transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
+  >
+    <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">
+      Medical Informatics &amp; Software Development
+    </h2>
+    <p className="text-sm text-gray-600 font-light mb-6">
+      Purpose-built tools that merge clinical workflow insight with modern app development, emphasizing secure, offline-capable designs
+      and transparent AI/ML integrations when appropriate.
+    </p>
+    <div className="space-y-6">
+      {projects.map((project) => (
+        <article key={project.title} className="bg-gray-50 border border-gray-100 rounded-lg p-5 shadow-sm">
+          <div className="flex flex-col md:flex-row md:items-baseline md:justify-between gap-2 mb-3">
+            <h3 className="text-base font-medium text-gray-900">{project.title}</h3>
+            <p className="text-xs uppercase tracking-wide text-gray-500">{project.role}</p>
           </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {/* Project 1: Surgic.AI */}
-            <Tooltip
-              content={
-                <div>
-                  <h4 className="font-medium mb-2">Surgic.AI - Enterprise Initiative</h4>
-                  <p className="mb-2">An enterprise focused on developing and deploying cutting-edge machine learning solutions tailored for medicine and surgery.</p>
-                  <p className="mb-2">Core Goals:</p>
-                  <ul className="list-disc pl-4 mb-2">
-                    <li>Enhance medical/surgical learning through AI tools.</li>
-                    <li>Improve the delivery of high-quality patient care.</li>
-                    <li>Mitigate physician burden through intelligent automation and support.</li>
-                    <li>Uphold rigorous ethical standards and patient safety in all applications.</li>
-                  </ul>
-                  <p>Projects like Rounder and Synthetic CXR Generation fall under the Surgic.AI framework.</p>
-                </div>
-              }
-              position="bottom"
-              width="max-w-md"
-            >
-              <div className="bg-gray-50 p-5 rounded-lg transition-all hover:shadow-md cursor-help">
-                <h3 className="text-base font-medium text-gray-900 mb-2">Surgic.AI</h3>
-                <p className="text-sm text-gray-600 font-light mb-3">Enterprise initiative providing ML solutions to enhance learning and patient care in medicine/surgery.</p>
-                <div className="flex flex-wrap gap-2 mb-3">
-                  <span className="bg-purple-50 text-purple-700 text-xs px-2 py-1 rounded-full">AI/ML</span>
-                  <span className="bg-blue-50 text-blue-700 text-xs px-2 py-1 rounded-full">Healthcare Tech</span>
-                  <span className="bg-red-50 text-red-700 text-xs px-2 py-1 rounded-full">Enterprise</span>
-                  <span className="bg-green-50 text-green-700 text-xs px-2 py-1 rounded-full">Surgery</span>
-                </div>
-                {/* <a href="https://github.com/[Your-GitHub-Username]/surgic-ai" target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 hover:underline">View Project →</a> */}
-                <span className="text-sm text-gray-400">Website coming soon</span>
-              </div>
-            </Tooltip>
-
-            {/* Project 2: Rounder App */}
-            <Tooltip
-              content={
-                <div>
-                  <h4 className="font-medium mb-2">Rounder - Clinical Workflow App</h4>
-                  <p className="mb-2">Mobile application designed to streamline clinical rounds documentation while maintaining HIPAA compliance.</p>
-                  <p className="mb-2">Key Features:</p>
-                  <ul className="list-disc pl-4 mb-2">
-                    <li>Voice-to-text note capture during rounds.</li>
-                    <li>Automatic formatting of notes into SOAP structure.</li>
-                    <li>Secure patient list creation via encrypted photo capture (OCR-based).</li>
-                    <li>Automatic assignment of notes to corresponding patients.</li>
-                    <li>Focus on hands-off operation to prioritize patient interaction.</li>
-                    <li>Ensures data privacy and security according to HIPAA standards.</li>
-                  </ul>
-                  <p>Currently under active development.</p>
-                </div>
-              }
-              position="bottom"
-              width="max-w-md"
-            >
-              <div className="bg-gray-50 p-5 rounded-lg transition-all hover:shadow-md cursor-help">
-                <h3 className="text-base font-medium text-gray-900 mb-2">Rounder App</h3>
-                <p className="text-sm text-gray-600 font-light mb-3">HIPAA-compliant app for efficient rounds notes (voice-to-SOAP, patient list photos).</p>
-                <div className="flex flex-wrap gap-2 mb-3">
-                  <span className="bg-blue-50 text-blue-700 text-xs px-2 py-1 rounded-full">Mobile App</span>
-                  <span className="bg-green-50 text-green-700 text-xs px-2 py-1 rounded-full">Clinical Workflow</span>
-                  <span className="bg-yellow-50 text-yellow-700 text-xs px-2 py-1 rounded-full">AI/ML</span>
-                  <span className="bg-red-50 text-red-700 text-xs px-2 py-1 rounded-full">HIPAA</span>
-                </div>
-                <span className="text-sm text-gray-400">Preview coming soon</span>
-              </div>
-            </Tooltip>
-
-            {/* Project 3: Synthetic CXR Generation */}
-            <Tooltip
-              content={
-                <div>
-                  <h4 className="font-medium mb-2">Synthetic Chest X-Ray (CXR) Generation</h4>
-                  <p className="mb-2">AI-powered tool to generate high-fidelity, anatomically accurate synthetic chest X-ray images for medical education.</p>
-                  <p className="mb-2">Project Goals:</p>
-                  <ul className="list-disc pl-4 mb-2">
-                    <li>Provide a diverse and extensive dataset for training residents and medical students.</li>
-                    <li>Generate images depicting various common and rare pathologies.</li>
-                    <li>Allow for controllable parameters to simulate different patient scenarios.</li>
-                    <li>Benchmark generative models (like GANs or Diffusion models) against real CXR datasets (e.g., VinDr-CXR) for fidelity.</li>
-                    <li>Integrate with educational platforms for interactive learning modules.</li>
-                  </ul>
-                  <p>Focuses on improving radiological interpretation skills without relying solely on limited real patient data.</p>
-                </div>
-              }
-              position="bottom"
-              width="max-w-md"
-            >
-              <div className="bg-gray-50 p-5 rounded-lg transition-all hover:shadow-md cursor-help">
-                <h3 className="text-base font-medium text-gray-900 mb-2">Synthetic CXR Generation</h3>
-                <p className="text-sm text-gray-600 font-light mb-3">AI tool generating realistic synthetic CXRs for medical education and training.</p>
-                <div className="flex flex-wrap gap-2 mb-3">
-                  <span className="bg-purple-50 text-purple-700 text-xs px-2 py-1 rounded-full">AI/ML</span>
-                  <span className="bg-orange-50 text-orange-700 text-xs px-2 py-1 rounded-full">Generative Models</span>
-                  <span className="bg-blue-50 text-blue-700 text-xs px-2 py-1 rounded-full">Medical Education</span>
-                  <span className="bg-green-50 text-green-700 text-xs px-2 py-1 rounded-full">Radiology</span>
-                </div>
-                <span className="text-sm text-gray-400">Preview coming soon</span>
-              </div>
-            </Tooltip>
-
-            {/* Add more projects as needed */}
-
-          </div>
-        </section>
+          <p className="text-sm text-gray-600 font-light mb-3">{project.summary}</p>
+          <ul className="list-disc pl-5 space-y-1 text-sm text-gray-600 font-light">
+            {project.highlights.map((highlight) => (
+              <li key={highlight}>{highlight}</li>
+            ))}
+          </ul>
+        </article>
+      ))}
+    </div>
+  </section>
 );
 
 export default ProgrammingSection;

--- a/src/components/sections/PublicationsSection.tsx
+++ b/src/components/sections/PublicationsSection.tsx
@@ -267,48 +267,82 @@ const PublicationsSection = ({ isVisible }: SectionProps) => (
           </div>
           
           <div className="mb-8">
-            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Manuscripts Under Review</h3>
+            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Manuscripts Under Review &amp; In Progress</h3>
             <ul className="space-y-4 text-sm text-gray-600 font-light">
               <Tooltip
                 content={
                   <div>
                     <h4 className="font-medium mb-2">A Property-Based Framework for Evaluating the Onset of Moral Status</h4>
-                    <p className="mb-2">This philosophical analysis proposes a novel framework for determining moral status based on emergent properties rather than categorical classifications.</p>
-                    <p className="mb-2">Key contributions:</p>
+                    <p className="mb-2">Proposes an emergent-property framework to evaluate when moral status begins and how those thresholds guide clinical policy.</p>
                     <ul className="list-disc pl-4 mb-2">
-                      <li>Critically evaluates existing theories of moral status attribution</li>
-                      <li>Develops a graduated, property-based approach to moral consideration</li>
-                      <li>Applies the framework to contentious bioethical cases</li>
-                      <li>Addresses implications for clinical practice and policy development</li>
+                      <li>Tests traditional conception-based arguments against the new framework.</li>
+                      <li>Applies criteria to bioethical dilemmas, including embryo research and end-of-life care.</li>
+                      <li>Outlines implications for surgical counseling and institutional ethics committees.</li>
                     </ul>
-                    <p>Currently under review at <em>Bioethics</em>, a leading journal in bioethical theory and analysis.</p>
+                    <p>Submitted to <em>Bioethics</em> in October 2025.</p>
                   </div>
                 }
                 position="bottom"
                 width="max-w-md"
               >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>. A Property-Based Framework for Evaluating the Onset of Moral Status. <em>Bioethics</em>. 2025 Mar 12. Submitted.</li>
+                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>. <strong>A Property-Based Framework for Evaluating the Onset of Moral Status.</strong> <em>Bioethics</em>. Submitted October 2025.</li>
               </Tooltip>
-              
+
               <Tooltip
                 content={
                   <div>
-                    <h4 className="font-medium mb-2">Bridging the Communication Gap: An Analysis of Google Translate and GPT-4o in English to Spanish Translation in Neurology</h4>
-                    <p className="mb-2">This study evaluates the accuracy and clinical safety of automated translation tools in neurological care.</p>
-                    <p className="mb-2">Research methodology:</p>
+                    <h4 className="font-medium mb-2">Bridging the Communication Gap in Neurology</h4>
+                    <p className="mb-2">Head-to-head comparison of Google Translate and GPT-4o for English-to-Spanish neurological phrase translation.</p>
                     <ul className="list-disc pl-4 mb-2">
-                      <li>Analysis of 120 standard neurological terms and phrases</li>
-                      <li>Comparative assessment of Google Translate and GPT-4o against certified medical translators</li>
-                      <li>Evaluation by bilingual neurologists for clinical accuracy</li>
-                      <li>Identification of high-risk mistranslations and error patterns</li>
+                      <li>120 standardized clinical prompts audited by bilingual neurologists.</li>
+                      <li>Accuracy, formality, and potential harm scoring frameworks.</li>
+                      <li>Recommendations for safe deployment of AI translation tools.</li>
                     </ul>
-                    <p>Submitted to <em>Patient Education and Counseling</em>, currently in the review process.</p>
+                    <p>Under review at <em>Patient Education and Counseling</em>; submitted February 2025.</p>
                   </div>
                 }
                 position="bottom"
                 width="max-w-md"
               >
-                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Alonzo BR, Cruz G. Bridging the Communication Gap: An Analysis of Google Translate and GPT-4o in English to Spanish Translation in Neurology. <em>Patient Education and Counseling</em>. 2025 Feb 28. Submitted.</li>
+                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Alonzo BR, Cruz G. <strong>Bridging the Communication Gap: An Analysis of Google Translate and GPT-4o in English to Spanish Translation in Neurology.</strong> <em>Patient Education and Counseling</em>. Under review.</li>
+              </Tooltip>
+
+              <Tooltip
+                content={
+                  <div>
+                    <h4 className="font-medium mb-2">Immunological Landscape Review</h4>
+                    <p className="mb-2">Collaborative review synthesizing innate and adaptive immune mechanisms in pre-cancerous colorectal lesions.</p>
+                    <ul className="list-disc pl-4 mb-2">
+                      <li>Maps immune microenvironment shifts along the adenoma–carcinoma sequence.</li>
+                      <li>Highlights intervention points for immunoprevention trials.</li>
+                      <li>Integrates single-cell and spatial transcriptomics data.</li>
+                    </ul>
+                    <p>Manuscript in preparation.</p>
+                  </div>
+                }
+                position="bottom"
+                width="max-w-md"
+              >
+                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Schmit S, Vilar E. <strong>A Review of the Immunological Landscape for Pre-Cancerous Colorectal Lesions.</strong> Manuscript in preparation.</li>
+              </Tooltip>
+
+              <Tooltip
+                content={
+                  <div>
+                    <h4 className="font-medium mb-2">Reddit Bariatric vs. Medication Analysis</h4>
+                    <p className="mb-2">Mixed-methods analysis of Reddit discussions comparing bariatric surgery and GLP-1 medications.</p>
+                    <ul className="list-disc pl-4 mb-2">
+                      <li>Topic modeling to surface pre-op concerns and post-op satisfaction themes.</li>
+                      <li>Sentiment tracking by intervention type and timeline.</li>
+                      <li>Implications for patient education and counseling.</li>
+                    </ul>
+                    <p>Manuscript in preparation.</p>
+                  </div>
+                }
+                position="bottom"
+                width="max-w-md"
+              >
+                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Patel D, Zaman JA. <strong>Pre-Operative Concerns and Post-Operative Satisfaction: Comparing Attitudes Towards Bariatric Surgery and Medication Intervention for Weight Loss on Reddit.</strong> Manuscript in preparation.</li>
               </Tooltip>
             </ul>
           </div>
@@ -316,6 +350,44 @@ const PublicationsSection = ({ isVisible }: SectionProps) => (
           <div className="mb-8">
             <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Conference Oral Presentations</h3>
             <ul className="space-y-4 text-sm text-gray-600 font-light">
+              <Tooltip
+                content={
+                  <div>
+                    <h4 className="font-medium mb-2">Benchmarking GPT Vision for Chest X-Ray Interpretation</h4>
+                    <p className="mb-2">Evaluates GPT’s radiology performance across zero-shot, one-shot, and few-shot learning setups.</p>
+                    <ul className="list-disc pl-4 mb-2">
+                      <li>VinDr-CXR dataset benchmarking with accuracy, recall, and F1 tracking.</li>
+                      <li>Prompt engineering to pair imaging with clinical vignettes.</li>
+                      <li>Highlights opportunities for safe adoption of agentic computer vision tools.</li>
+                    </ul>
+                    <p>Accepted for oral presentation at the 23rd Annual Academic Surgical Congress.</p>
+                  </div>
+                }
+                position="bottom"
+                width="max-w-md"
+              >
+                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Chen C, Shahbazov R. <strong>Benchmarking Robust Computer Vision Models: GPT’s Vision Capabilities in Radiological Interpretation of Chest X-Rays with Zero-Shot, One-Shot, and Few-Shot Learning.</strong> <em>Annual Academic Surgical Congress</em>. 23rd Annual Conference; Accepted for oral presentation.</li>
+              </Tooltip>
+
+              <Tooltip
+                content={
+                  <div>
+                    <h4 className="font-medium mb-2">Assessing Implicit Bias in Clinical LLMs</h4>
+                    <p className="mb-2">Tests GPT-4o decision support against vignette permutations to quantify bias patterns.</p>
+                    <ul className="list-disc pl-4 mb-2">
+                      <li>Systematically varies patient demographics within identical surgical cases.</li>
+                      <li>Measures treatment recommendations, counseling language, and confidence scoring.</li>
+                      <li>Discusses safeguards for algorithmic fairness in perioperative AI tools.</li>
+                    </ul>
+                    <p>Accepted for oral presentation at the 23rd Annual Academic Surgical Congress.</p>
+                  </div>
+                }
+                position="bottom"
+                width="max-w-md"
+              >
+                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Mohanraj D, John M, Malcom M, McKay S, Marrin A, Singh TP. <strong>Assessing Implicit Bias in the Clinical Decision-Making of Large Language Models.</strong> <em>Annual Academic Surgical Congress</em>. 23rd Annual Conference; Accepted for oral presentation.</li>
+              </Tooltip>
+
               {/* Added ASC 2025 Presentation (Presented) */}
               <Tooltip
                 content={
@@ -450,6 +522,49 @@ const PublicationsSection = ({ isVisible }: SectionProps) => (
             </ul>
           </div>
           
+          <div className="mb-8">
+            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Abstracts Under Consideration for Oral Presentation</h3>
+            <ul className="space-y-4 text-sm text-gray-600 font-light">
+              <Tooltip
+                content={
+                  <div>
+                    <h4 className="font-medium mb-2">Reddit Bariatric vs. Medication SAGES Submission</h4>
+                    <p className="mb-2">Extends the Reddit analysis to a conference-ready dataset for SAGES 2026.</p>
+                    <ul className="list-disc pl-4 mb-2">
+                      <li>Compares perceptions of Roux-en-Y gastric bypass, sleeve gastrectomy, and GLP-1 medications.</li>
+                      <li>Highlights pre-operative concerns, motivators, and post-operative satisfaction themes.</li>
+                      <li>Positions social listening as an adjunct to surgical counseling.</li>
+                    </ul>
+                    <p>Under review for the Society of American Gastrointestinal and Endoscopic Surgeons (SAGES) 2026 meeting.</p>
+                  </div>
+                }
+                position="bottom"
+                width="max-w-md"
+              >
+                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Mohanraj D, John M, Malcom M, McKay S, Marrin A, Zaman J. <strong>Pre-Operative Concerns and Post-Operative Satisfaction: Comparing Attitudes Towards Bariatric Surgery and Medication Intervention for Weight Loss on Reddit.</strong> <em>SAGES 2026.</em> Under review.</li>
+              </Tooltip>
+
+              <Tooltip
+                content={
+                  <div>
+                    <h4 className="font-medium mb-2">MARCUS Emerging Technology Submission</h4>
+                    <p className="mb-2">Showcases the MARCUS retrieval-augmented system for SAGES Emerging Technology 2026.</p>
+                    <ul className="list-disc pl-4 mb-2">
+                      <li>Focuses on multi-tenant architecture for residency information centralization.</li>
+                      <li>Demonstrates version control, audit logging, and embedded citations.</li>
+                      <li>Outlines roadmap for multimodal expansion.</li>
+                    </ul>
+                    <p>Pending submission to the SAGES Emerging Technology session (2026).</p>
+                  </div>
+                }
+                position="bottom"
+                width="max-w-md"
+              >
+                <li className="cursor-help"><span className="font-medium">Del Carmen GA</span>, Shukla D, Zaman J. <strong>Multimodal Agentic Retrieval for Clinical Utility and Synthesis (MARCUS): A Retrieval-Augmented Generation System for Residency Information Centralization.</strong> <em>SAGES Emerging Technology 2026.</em> Pending submission.</li>
+              </Tooltip>
+            </ul>
+          </div>
+
           <div>
             <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Conference Poster Presentations</h3>
             <ul className="space-y-4 text-sm text-gray-600 font-light">

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -2,44 +2,73 @@ interface SectionProps {
   isVisible: boolean;
 }
 
+const skillGroups = [
+  {
+    title: 'Research & Data',
+    items: [
+      'STATA for clinical outcomes analysis',
+      'IRB protocol drafting, submission, and amendment revision',
+      'REDCap and Microsoft Access for database design and data capture',
+    ],
+  },
+  {
+    title: 'Programming & Informatics',
+    items: [
+      'Python for data analysis, NLP, and model evaluation',
+      'SwiftUI and Xcode for iOS app development',
+      'Basic web development (HTML/CSS/JavaScript)',
+      'Familiarity with ML/LLM workflows',
+    ],
+  },
+  {
+    title: 'Clinical Systems',
+    items: ['EPIC electronic health record'],
+  },
+  {
+    title: 'Languages',
+    items: ['English (native)', 'Spanish (conversational)'],
+  },
+];
+
 const SkillsSection = ({ isVisible }: SectionProps) => (
-  <section 
-          id="skills" 
-          className={`mb-16 transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
-        >
-          <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Skills & Interests</h2>
-          
-          <div className="mb-8">
-            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Technical Skills</h3>
-            <div className="flex flex-wrap gap-x-6 gap-y-2">
-              <span className="text-sm text-gray-600 font-light">STATA</span>
-              <span className="text-sm text-gray-600 font-light">RedCap</span>
-              <span className="text-sm text-gray-600 font-light">EPIC</span>
-              <span className="text-sm text-gray-600 font-light">Python</span>
-              <span className="text-sm text-gray-600 font-light">Microsoft Access</span>
-              <span className="text-sm text-gray-600 font-light">IRB Submissions</span>
-            </div>
-          </div>
-          
-          <div className="mb-8">
-            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Professional Memberships</h3>
-            <ul className="text-sm text-gray-600 font-light space-y-1">
-              <li>• American College of Surgeons (2023 – Present)</li>
-              <li>• American Medical Association (2020 – Present)</li>
-              <li>• Texas Medical Association (2020 – Present)</li>
-              <li>• Harris County Medical Society (2020 – Present)</li>
-            </ul>
-          </div>
-          
-          <div>
-            <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Interests</h3>
-            <ul className="text-sm text-gray-600 font-light space-y-1">
-              <li>• Creative writing: Self-published science fiction and horror fiction</li>
-              <li>• Reading: Horror fiction and philosophical literature</li>
-              <li>• Music production: Compositions using FL Studio and MIDI synthesizers</li>
-            </ul>
-          </div>
-        </section>
+  <section
+    id="skills"
+    className={`mb-16 transition-opacity duration-700 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
+  >
+    <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Skills &amp; Interests</h2>
+
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+      {skillGroups.map((group) => (
+        <div key={group.title} className="bg-gray-50 rounded-lg p-4">
+          <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">{group.title}</h3>
+          <ul className="list-disc pl-5 space-y-1 text-sm text-gray-600 font-light">
+            {group.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+
+    <div className="mb-8">
+      <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Professional Memberships</h3>
+      <ul className="text-sm text-gray-600 font-light space-y-1">
+        <li>• American College of Surgeons (2023 – Present)</li>
+        <li>• American Medical Association (2020 – Present)</li>
+        <li>• Texas Medical Association (2020 – Present)</li>
+        <li>• Harris County Medical Society (2020 – Present)</li>
+      </ul>
+    </div>
+
+    <div>
+      <h3 className="text-sm uppercase tracking-wider text-gray-500 mb-3">Interests</h3>
+      <ul className="text-sm text-gray-600 font-light space-y-1">
+        <li>• Creative writing: Self-published science fiction and horror fiction</li>
+        <li>• Reading: Horror fiction and philosophical literature</li>
+        <li>• Music production: Compositions using FL Studio and MIDI synthesizers</li>
+      </ul>
+    </div>
+  </section>
 );
 
 export default SkillsSection;

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,14 +1,15 @@
 export const navSections = [
   { id: 'education', label: 'Education' },
+  { id: 'licensure', label: 'Licensure' },
   { id: 'about', label: 'About' },
   { id: 'publications', label: 'Publications' },
   { id: 'research', label: 'Research' },
+  { id: 'programming', label: 'Informatics' },
+  { id: 'future', label: 'Research in Progress' },
   { id: 'honors', label: 'Honors' },
   { id: 'experience', label: 'Experience' },
   { id: 'skills', label: 'Skills' },
-  { id: 'programming', label: 'Programming' },
-  { id: 'future', label: 'Future' },
-  { id: 'contact', label: 'Contact' }
+  { id: 'contact', label: 'Contact' },
 ] as const;
 
 export type NavSection = typeof navSections[number];


### PR DESCRIPTION
## Summary
- add a dedicated licensure & certifications section, refreshed objective text, and updated header metadata
- expand the publications & presentations area with new manuscripts, accepted ASC abstracts, and a cleaned up under-consideration list
- introduce a medical informatics & software development section, reorganize the skills block, and surface MARCUS plus other app work

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c199b2e6483238d9a671876b72f62)