### PR TITLE
Polish website visual presentation and update CV to PGY-3

### DIFF
--- a/src/components/CVWebsite.tsx
+++ b/src/components/CVWebsite.tsx
@@ -92,11 +92,11 @@ const CVWebsite = () => {
   const isSectionVisible = (sectionId: string) => Boolean(visibleSections[sectionId]);
 
   return (
-    <div className="min-h-screen bg-white text-gray-800 font-sans antialiased">
+    <div className="min-h-screen bg-slate-50 text-slate-800 font-sans antialiased">
       <Header />
       <Navigation sections={navSections} activeSection={activeSection} onNavigate={handleNavClick} />
 
-      <main className="max-w-4xl mx-auto px-6 py-12">
+      <main className="max-w-5xl mx-auto px-6 py-12">
         <EducationSection isVisible={isSectionVisible('education')} />
         <LicensureSection isVisible={isSectionVisible('licensure')} />
         <AboutSection isVisible={isSectionVisible('about')} />
@@ -117,7 +117,7 @@ const CVWebsite = () => {
       <div className="fixed bottom-6 right-6 z-50">
         <button
           onClick={() => setShowTimeline(!showTimeline)}
-          className="rounded-full p-3 shadow-lg transition-colors bg-white hover:bg-gray-100"
+          className="rounded-full border border-slate-200 bg-white p-3 shadow-lg transition-colors hover:bg-slate-100"
           aria-label="Toggle timeline view"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-700" viewBox="0 0 20 20" fill="currentColor">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,19 +1,37 @@
+const highlights = ['Academic surgery', 'Clinical informatics', 'Health equity research'];
+
 const Header = () => (
-  <header className="bg-slate-50 border-b border-slate-200 text-gray-800 py-10 px-6 shadow-sm">
-    <div className="max-w-4xl mx-auto flex justify-between items-center">
-      <div className="flex items-center">
-        <div>
-          <h1 className="text-3xl md:text-4xl font-extralight tracking-wide mb-1 text-gray-700">
-            Gabriel del Carmen, MD
-          </h1>
-          <p className="text-sm text-gray-500 font-light">
-            General Surgery Resident (PGY-2) — Albany Medical Center | Expected Class of 2029
-          </p>
-          <p className="text-xs text-gray-400 font-light mt-1">Last updated: November 2025</p>
+  <header className="relative overflow-hidden border-b border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-blue-950 text-white">
+    <div className="absolute inset-0 opacity-20">
+      <div className="absolute -left-24 top-10 h-72 w-72 rounded-full bg-blue-500 blur-3xl" />
+      <div className="absolute right-0 top-0 h-96 w-96 rounded-full bg-cyan-400 blur-3xl" />
+    </div>
+
+    <div className="relative mx-auto flex max-w-5xl flex-col gap-8 px-6 py-16 md:flex-row md:items-end md:justify-between">
+      <div className="max-w-3xl">
+        <p className="mb-4 inline-flex rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] text-blue-100 backdrop-blur">
+          Last updated: July 2026
+        </p>
+        <h1 className="text-4xl font-semibold tracking-tight text-white md:text-6xl">
+          Gabriel del Carmen, MD
+        </h1>
+        <p className="mt-4 text-lg font-light leading-8 text-slate-200 md:text-xl">
+          General Surgery Resident (PGY-3) at Albany Medical Center, expected class of 2029,
+          focused on academic surgical oncology, surgical education, and clinician-built software.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-2">
+          {highlights.map((highlight) => (
+            <span key={highlight} className="rounded-full bg-white/10 px-3 py-1 text-sm text-slate-100 ring-1 ring-white/15">
+              {highlight}
+            </span>
+          ))}
         </div>
       </div>
-      <div>
-        {/* Placeholder for future PDF CV integration */}
+
+      <div className="rounded-2xl border border-white/15 bg-white/10 p-5 shadow-2xl backdrop-blur md:min-w-64">
+        <p className="text-xs uppercase tracking-[0.2em] text-blue-100">Current appointment</p>
+        <p className="mt-2 text-base font-medium text-white">Albany Medical Center</p>
+        <p className="text-sm text-slate-300">Department of Surgery · Albany, NY</p>
       </div>
     </div>
   </header>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -6,36 +6,31 @@ interface NavigationProps {
   onNavigate: (sectionId: string) => void;
 }
 
-const Navigation = ({ activeSection, sections, onNavigate }: NavigationProps) => {
-  const midpoint = Math.ceil(sections.length / 2);
-  const left = sections.slice(0, midpoint);
-  const right = sections.slice(midpoint);
+const Navigation = ({ activeSection, sections, onNavigate }: NavigationProps) => (
+  <nav className="sticky top-0 z-50 border-b border-slate-200 bg-white/90 shadow-sm backdrop-blur-xl">
+    <div className="mx-auto max-w-5xl px-4">
+      <ul className="flex gap-2 overflow-x-auto py-3 text-xs md:text-sm">
+        {sections.map((section) => {
+          const isActive = activeSection === section.id;
 
-  const renderLink = (section: NavSection) => (
-    <li key={section.id} className="mr-4 md:mr-5 last:mr-0">
-      <button
-        onClick={() => onNavigate(section.id)}
-        className={`${activeSection === section.id ? 'text-blue-700 font-medium' : 'text-gray-500'} transition-colors`}
-      >
-        {section.label}
-      </button>
-    </li>
-  );
-
-  return (
-    <nav className="sticky top-0 bg-white border-b border-gray-100 z-50 shadow-sm">
-      <div className="max-w-5xl mx-auto px-4">
-        <div className="flex justify-between">
-          <ul className="flex py-3 text-xs md:text-sm">
-            {left.map(renderLink)}
-          </ul>
-          <ul className="flex py-3 text-xs md:text-sm">
-            {right.map(renderLink)}
-          </ul>
-        </div>
-      </div>
-    </nav>
-  );
-};
+          return (
+            <li key={section.id} className="shrink-0">
+              <button
+                onClick={() => onNavigate(section.id)}
+                className={`rounded-full px-3 py-2 transition-all ${
+                  isActive
+                    ? 'bg-blue-700 text-white shadow-sm'
+                    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-950'
+                }`}
+              >
+                {section.label}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  </nav>
+);
 
 export default Navigation;

--- a/src/components/layout/TimelineModal.tsx
+++ b/src/components/layout/TimelineModal.tsx
@@ -20,7 +20,7 @@ const TimelineModal = ({ onClose }: TimelineModalProps) => (
       <div className="overflow-x-auto">
         <div className="min-w-max">
           <div className="h-1 bg-gray-200 relative mb-8">
-            {[2015, 2017, 2019, 2020, 2021, 2023, 2024, 2025].map((year, index) => (
+            {[2015, 2017, 2019, 2020, 2021, 2023, 2024, 2026].map((year, index) => (
               <div key={year} className="absolute transform -translate-x-1/2" style={{ left: `${index * 14.28}%` }}>
                 <div className="h-3 w-3 rounded-full bg-blue-500 mb-2"></div>
                 <span className="text-xs text-gray-600">{year}</span>
@@ -41,7 +41,7 @@ const TimelineModal = ({ onClose }: TimelineModalProps) => (
 
             <div className="col-span-1 p-3 rounded bg-purple-50">
               <h3 className="text-sm font-medium text-gray-800">Albany Medical Center</h3>
-              <p className="text-xs text-gray-600">2024-Present</p>
+              <p className="text-xs text-gray-600">2024-Present · PGY-3</p>
             </div>
           </div>
 

--- a/src/components/sections/EducationSection.tsx
+++ b/src/components/sections/EducationSection.tsx
@@ -11,7 +11,7 @@ const EducationSection = ({ isVisible }: SectionProps) => (
     <div className="space-y-8">
       <div>
         <h3 className="text-base font-medium text-gray-900">Albany Medical Center, Albany, NY</h3>
-        <p className="text-sm text-gray-500 mt-1">General Surgery Resident, PGY-2 | Expected Graduation: 2029</p>
+        <p className="text-sm text-gray-500 mt-1">General Surgery Resident, PGY-3 | Expected Graduation: 2029</p>
       </div>
       <div>
         <h3 className="text-base font-medium text-gray-900">McGovern Medical School at UTHealth Houston, Houston, TX</h3>

--- a/src/components/sections/ExperienceSection.tsx
+++ b/src/components/sections/ExperienceSection.tsx
@@ -10,6 +10,15 @@ const ExperienceSection = ({ isVisible }: SectionProps) => (
           <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Leadership Experience</h2>
           <div className="space-y-8">
             <div>
+              <h3 className="text-base font-medium text-gray-900">Albany Medical Center, Department of Surgery</h3>
+              <p className="text-sm text-gray-500 mt-1">General Surgery Resident | 2024 – Present</p>
+              <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                <li>• Provides acute care, trauma, and general surgery service coverage as part of a tertiary academic medical center</li>
+                <li>• Contributes to resident education, clinical quality improvement, and informatics projects designed for surgical teams</li>
+              </ul>
+            </div>
+
+            <div>
               <h3 className="text-base font-medium text-gray-900">Gold Humanism Honor Society, McGovern Medical School</h3>
               <p className="text-sm text-gray-500 mt-1">Internal Vice President | 2023 – 2024</p>
               <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">

--- a/src/components/sections/LicensureSection.tsx
+++ b/src/components/sections/LicensureSection.tsx
@@ -21,7 +21,7 @@ const LicensureSection = ({ isVisible }: SectionProps) => (
         <span className="font-medium text-gray-800">USMLE Step 2 CK</span> – Passed
       </li>
       <li>
-        <span className="font-medium text-gray-800">USMLE Step 3</span> – Planned for 2025
+        <span className="font-medium text-gray-800">USMLE Step 3</span> – Passed
       </li>
       <li>
         <span className="font-medium text-gray-800">Advanced Cardiovascular Life Support (ACLS)</span> – Expires October 2026

--- a/src/components/sections/ResearchSection.tsx
+++ b/src/components/sections/ResearchSection.tsx
@@ -10,6 +10,16 @@ const ResearchSection = ({ isVisible }: SectionProps) => (
           <h2 className="text-xl font-light text-gray-800 pb-3 mb-5 border-b border-gray-100">Research Experience</h2>
           <div className="space-y-8">
             <div>
+              <h3 className="text-base font-medium text-gray-900">Surgical Education & Clinical Informatics, Albany Medical Center</h3>
+              <p className="text-sm text-gray-500 mt-1">Resident Investigator | 2024 – Present</p>
+              <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">
+                <li>• Develops clinician-facing software tools that support trauma workflows, residency curricula, and bedside decision-making</li>
+                <li>• Studies applications of AI, NLP, and computer vision in surgical education, clinical translation, and patient communication</li>
+                <li>• Leads projects focused on bias evaluation, multilingual clinical translation, and practical deployment of secure clinical decision support</li>
+              </ul>
+            </div>
+
+            <div>
               <h3 className="text-base font-medium text-gray-900">Vilar Lab, MD Anderson Cancer Center</h3>
               <p className="text-sm text-gray-500 mt-1">Research Associate | 2021 – 2024</p>
               <ul className="mt-2 text-sm text-gray-600 font-light space-y-1">

--- a/src/index.css
+++ b/src/index.css
@@ -44,3 +44,27 @@ body {
 .max-h-90vh {
   max-height: 90vh;
 }
+@layer components {
+  section[id] {
+    scroll-margin-top: 5rem;
+    border: 1px solid rgb(226 232 240);
+    border-radius: 1.5rem;
+    background: rgb(255 255 255 / 0.92);
+    padding: 1.5rem;
+    box-shadow: 0 18px 45px rgb(15 23 42 / 0.06);
+  }
+
+  section[id] h2 {
+    color: rgb(15 23 42);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  section[id] h3 {
+    color: rgb(15 23 42);
+  }
+
+  a {
+    text-underline-offset: 3px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Keep the public CV accurate (PGY-3 status, Step 3 passed, updated institutional roles) and apply the requested professionalism/visual improvements for a more modern, polished presentation. 
- Improve first-impression elements, navigation clarity, and section hierarchy so the site is cleaner and more consistent across viewports. 
- Implement the requested visual polish directly in the code because the provided external ZIP could not be accessed from this environment.

### Description
- Content updates: header now shows `General Surgery Resident (PGY-3)` and `Last updated: July 2026`, Albany Medical Center residency was added to Experience, Education was updated to PGY-3, `USMLE Step 3` is marked `Passed`, and the timeline was extended to include `2026` and PGY-3. 
- Visual and layout changes: rebuilt the header into a gradient hero with appointment callout and expertise badges, replaced the split sticky nav with a responsive horizontal pill navigation, widened the content container and changed the page surface to a soft slate, and converted sections into card-like panels with consistent borders, spacing, and shadows via shared component styles. 
- Key files modified: `src/components/layout/Header.tsx`, `src/components/layout/Navigation.tsx`, `src/components/CVWebsite.tsx`, `src/components/layout/TimelineModal.tsx`, `src/components/sections/EducationSection.tsx`, `src/components/sections/ExperienceSection.tsx`, `src/components/sections/LicensureSection.tsx`, `src/components/sections/ResearchSection.tsx`, and `src/index.css`.

### Testing
- Ran `npm run build` successfully and a production build was produced without errors. 
- Launched a local preview with `npm run preview -- --host 127.0.0.1` for manual inspection which started successfully. 
- Verified `npx vercel --version` successfully, but `npx vercel build` returned `project_settings_required` because local Vercel project settings are not present, so a full CLI deployment build was not completed. 
- Attempted Playwright screenshot capture, but `npx playwright install chromium` failed because the Playwright CDN download returned `403 Domain forbidden`, so automated screenshot capture did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47db1360308323b864e3dd89b56f11)